### PR TITLE
feature/detail-page-chapter

### DIFF
--- a/CONTRIBUTTING.md
+++ b/CONTRIBUTTING.md
@@ -27,21 +27,28 @@ Si votre PR **contient une nouvelle fonctionnalité, un correctif visible, ou un
 
 ### 2. 🧾 Rédigez un changelog dans la description de la PR :
 
+**⚠️ IMPORTANT : Le changelog est destiné aux UTILISATEURS FINAUX, pas aux développeurs !**
+
+Il doit être :
+- **Simple et compréhensible** : Pas de jargon technique
+- **Centré sur les bénéfices utilisateur** : Ce que l'utilisateur peut voir/faire de nouveau
+- **Sans détails techniques** : Pas de noms de fichiers, de services, de configurations internes
+
 Entourez les notes de publication entre les balises :
 
 ```
 <!-- CHANGELOG:START -->
 ### ✨ Ajouts
-- Nouvelle fonctionnalité X
-- Intégration de l'outil Y
+- Vous pouvez maintenant choisir la langue de l'application dans les paramètres
+- L'application charge plus rapidement les informations de profil
 
 ### 🐛 Corrections
-- Résolution du bug Z
-- Amélioration des performances de la page d’accueil
+- Correction du bug d'affichage sur la page d'accueil
+- Les mises à jour s'installent maintenant correctement
 <!-- CHANGELOG:END -->
 ```
 
-Le contenu entre ces balises sera utilisé pour la **release GitHub** et pour mettre à jour automatiquement le fichier `version.json`.
+Le contenu entre ces balises sera utilisé pour la **release GitHub** et pour mettre à jour automatiquement le fichier `version.json` qui sera affiché aux utilisateurs dans l'application.
 
 ---
 
@@ -71,12 +78,16 @@ Cette PR ajoute un système qui détecte la version actuelle et propose une mise
 
 <!-- CHANGELOG:START -->
 ### ✨ Ajouts
-- Système de vérification automatique des mises à jour
-- Boîte de dialogue avec bouton "Mettre à jour maintenant"
+- L'application vous notifie automatiquement quand une nouvelle version est disponible
+- Vous pouvez mettre à jour l'application directement depuis l'app
 
 ### 🐛 Corrections
-- Bug de redirection après splash screen corrigé
+- Correction du problème de redirection au démarrage de l'application
 <!-- CHANGELOG:END -->
+
+## 📋 Détails techniques (pour les développeurs)
+
+Cette section peut contenir des détails techniques pour les développeurs, mais ne sera PAS affichée aux utilisateurs.
 ```
 
 ---

--- a/lib/core/network/http_service.dart
+++ b/lib/core/network/http_service.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/http.dart';
 import 'package:mangatracker/features/auth/exceptions/invalid_credentials.exception.dart';
@@ -50,18 +51,21 @@ class HttpService {
 
 
     if (res.statusCode == HttpStatus.unauthorized) {
+      debugPrint('⚠️ HttpService: Réponse 401, tentative de refresh...');
 
       final refreshToken = await _storage.readSecureData('refreshToken');
       if (refreshToken == null || _auth.isTokenExpired(refreshToken)) {
+        debugPrint('❌ HttpService: Les deux tokens sont expirés');
         throw InvalidCredentialsException('Both tokens expired');
       }
 
       final refreshed = await _auth.refreshAccessToken();
       if (!refreshed) {
+        debugPrint('❌ HttpService: Impossible de rafraîchir le access token');
         throw InvalidCredentialsException('Could not refresh access token');
       }
 
-
+      debugPrint('🔄 HttpService: Réessai de la requête avec le nouveau token...');
       headers = await _addAuthHeaders(null);
 
       res = await _performRequest(
@@ -71,8 +75,10 @@ class HttpService {
         body: body,
       );
       if (res.statusCode == HttpStatus.unauthorized) {
+        debugPrint('❌ HttpService: Toujours 401 après refresh - credentials invalides');
         throw InvalidCredentialsException('Invalid credentials');
       }
+      debugPrint('✅ HttpService: Requête réussie après refresh');
     }
 
     return res;
@@ -86,16 +92,24 @@ class HttpService {
     String? refreshToken = await _storage.readSecureData('refreshToken');
 
     if (refreshToken == null || _auth.isTokenExpired(refreshToken)) {
+      debugPrint('⚠️ HttpService: Refresh token expiré ou absent');
       throw InvalidCredentialsException('Refresh token expired');
     }
 
 
     if (accessToken == null || _auth.isTokenExpired(accessToken)) {
+      debugPrint('🔄 HttpService: Access token expiré, tentative de refresh...');
       final ok = await _auth.refreshAccessToken();
       if (!ok) {
+        debugPrint('❌ HttpService: Échec du refresh du access token');
         throw InvalidCredentialsException('Could not refresh access token');
       }
       accessToken = await _storage.readSecureData('accessToken');
+      if (accessToken == null) {
+        debugPrint('❌ HttpService: Access token toujours null après refresh');
+        throw InvalidCredentialsException('Access token not available after refresh');
+      }
+      debugPrint('✅ HttpService: Access token rafraîchi avec succès');
     }
 
     headers[HttpHeaders.authorizationHeader] = 'Bearer $accessToken';

--- a/lib/core/services/app_update_service.dart
+++ b/lib/core/services/app_update_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:open_file/open_file.dart';
@@ -88,7 +89,7 @@ class AppUpdateService {
 
       return ChangelogInfo(relevantNotes);
     } catch (e, st) {
-      print('getAllChangelogs error: $e\n$st');
+      debugPrint('getAllChangelogs error: $e\n$st');
       return null;
     }
   }
@@ -123,7 +124,7 @@ class AppUpdateService {
       }
       return null;
     } catch (e, st) {
-      print('getNewChangelog error: $e\n$st');
+      debugPrint('getNewChangelog error: $e\n$st');
       return null;
     }
   }

--- a/lib/core/services/cache_helper_service.dart
+++ b/lib/core/services/cache_helper_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:mangatracker/core/service_locator/service_locator.dart';
 import 'package:mangatracker/features/manga/dto/manga_quick_view.dto.dart';
 import 'package:mangatracker/features/manga/dto/manga_detail.dto.dart';
@@ -19,7 +20,7 @@ class CacheHelperService {
       await _cacheService.cacheLibrary(data);
       return data;
     } catch (e) {
-      print('Erreur réseau, fallback vers cache: $e');
+      debugPrint('Erreur réseau, fallback vers cache: $e');
       // Laisser l'exception remonter pour que les BLoCs puissent détecter l'erreur réseau
       rethrow;
     }
@@ -36,7 +37,7 @@ class CacheHelperService {
       await _cacheService.cacheHomePageData(data);
       return data;
     } catch (e) {
-      print('Erreur réseau, fallback vers cache: $e');
+      debugPrint('Erreur réseau, fallback vers cache: $e');
       // Laisser l'exception remonter pour que les BLoCs puissent détecter l'erreur réseau
       rethrow;
     }
@@ -53,7 +54,7 @@ class CacheHelperService {
       await _cacheService.cacheMangaDetail(muId, data);
       return data;
     } catch (e) {
-      print('Erreur réseau, fallback vers cache: $e');
+      debugPrint('Erreur réseau, fallback vers cache: $e');
       // Laisser l'exception remonter pour que les BLoCs puissent détecter l'erreur réseau
       rethrow;
     }
@@ -71,7 +72,7 @@ class CacheHelperService {
       await _cacheService.cacheSearchResults(query, data);
       return data;
     } catch (e) {
-      print('Erreur réseau, fallback vers cache: $e');
+      debugPrint('Erreur réseau, fallback vers cache: $e');
       // Laisser l'exception remonter pour que les BLoCs puissent détecter l'erreur réseau
       rethrow;
     }

--- a/lib/core/services/connectivity_service.dart
+++ b/lib/core/services/connectivity_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/foundation.dart';
 
 /// Service de gestion de la connectivité réseau
 /// Permet de détecter l'état de connexion et d'écouter les changements
@@ -23,7 +24,7 @@ class ConnectivityService {
       // Écouter les changements de connectivité
       _connectivity.onConnectivityChanged.listen(_onConnectivityChanged);
     } catch (e) {
-      print('⚠️ Erreur lors de l\'initialisation du ConnectivityService: $e');
+      debugPrint('⚠️ Erreur lors de l\'initialisation du ConnectivityService: $e');
       // En cas d'erreur, supposer que l'appareil est connecté
       _isConnected = true;
       _connectivityController.add(true);
@@ -43,7 +44,7 @@ class ConnectivityService {
       
       return isConnected;
     } catch (e) {
-      print('⚠️ Erreur lors de la vérification de connectivité: $e');
+      debugPrint('⚠️ Erreur lors de la vérification de connectivité: $e');
       // En cas d'erreur, supposer que l'appareil est connecté
       return true;
     }

--- a/lib/core/services/offline_cache_service.dart
+++ b/lib/core/services/offline_cache_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:mangatracker/core/service_locator/service_locator.dart';
 import 'package:mangatracker/core/storage/services/storage.service.dart';
 import 'package:mangatracker/features/manga/dto/manga_quick_view.dto.dart';
@@ -115,7 +116,7 @@ class OfflineCacheService {
       await _storage.writeSecureData(_libraryCacheKey, jsonEncode(json));
       await _updateLastSyncTimestamp();
     } catch (e) {
-      print('Erreur lors du cache de la bibliothèque: $e');
+      debugPrint('Erreur lors du cache de la bibliothèque: $e');
     }
   }
   
@@ -128,7 +129,7 @@ class OfflineCacheService {
         return jsonList.map((json) => MangaQuickViewDto.fromJson(json)).toList();
       }
     } catch (e) {
-      print('Erreur lors de la récupération du cache bibliothèque: $e');
+      debugPrint('Erreur lors de la récupération du cache bibliothèque: $e');
     }
     return null;
   }
@@ -139,7 +140,7 @@ class OfflineCacheService {
       final key = '$_mangaDetailCacheKey$muId';
       await _storage.writeSecureData(key, jsonEncode(mangaDetail.toJson()));
     } catch (e) {
-      print('Erreur lors du cache des détails manga: $e');
+      debugPrint('Erreur lors du cache des détails manga: $e');
     }
   }
   
@@ -152,7 +153,7 @@ class OfflineCacheService {
         return MangaDetailDto.fromJson(jsonDecode(cached));
       }
     } catch (e) {
-      print('Erreur lors de la récupération du cache détails manga: $e');
+      debugPrint('Erreur lors de la récupération du cache détails manga: $e');
     }
     return null;
   }
@@ -164,7 +165,7 @@ class OfflineCacheService {
       await _storage.writeSecureData(_homePageCacheKey, jsonEncode(json));
       await _updateCacheMetadata('homepage', DateTime.now());
     } catch (e) {
-      print('Erreur lors du cache de la page d\'accueil: $e');
+      debugPrint('Erreur lors du cache de la page d\'accueil: $e');
     }
   }
   
@@ -177,7 +178,7 @@ class OfflineCacheService {
         return jsonList.map((json) => MangaQuickViewDto.fromJson(json)).toList();
       }
     } catch (e) {
-      print('Erreur lors de la récupération du cache page d\'accueil: $e');
+      debugPrint('Erreur lors de la récupération du cache page d\'accueil: $e');
     }
     return null;
   }
@@ -190,7 +191,7 @@ class OfflineCacheService {
       await _storage.writeSecureData(key, jsonEncode(json));
       await _updateCacheMetadata('search_$query', DateTime.now());
     } catch (e) {
-      print('Erreur lors du cache des résultats de recherche: $e');
+      debugPrint('Erreur lors du cache des résultats de recherche: $e');
     }
   }
   
@@ -204,7 +205,7 @@ class OfflineCacheService {
         return jsonList.map((json) => MangaQuickViewDto.fromJson(json)).toList();
       }
     } catch (e) {
-      print('Erreur lors de la récupération du cache recherche: $e');
+      debugPrint('Erreur lors de la récupération du cache recherche: $e');
     }
     return null;
   }
@@ -215,7 +216,7 @@ class OfflineCacheService {
       await _storage.writeSecureData(_userInfoCacheKey, jsonEncode(userInfo.toJson()));
       await _updateCacheMetadata('user_info', DateTime.now());
     } catch (e) {
-      print('Erreur lors du cache des informations utilisateur: $e');
+      debugPrint('Erreur lors du cache des informations utilisateur: $e');
     }
   }
 
@@ -227,7 +228,7 @@ class OfflineCacheService {
         return UserInformationDto.fromJson(jsonDecode(cached));
       }
     } catch (e) {
-      print('Erreur lors de la récupération du cache informations utilisateur: $e');
+      debugPrint('Erreur lors de la récupération du cache informations utilisateur: $e');
     }
     return null;
   }
@@ -239,7 +240,7 @@ class OfflineCacheService {
       existing.add(action.toJson());
       await _storage.writeSecureData(_offlineQueueKey, jsonEncode(existing));
     } catch (e) {
-      print('Erreur lors de l\'ajout à la queue hors ligne: $e');
+      debugPrint('Erreur lors de l\'ajout à la queue hors ligne: $e');
     }
   }
   
@@ -251,7 +252,7 @@ class OfflineCacheService {
         return List<Map<String, dynamic>>.from(jsonDecode(cached));
       }
     } catch (e) {
-      print('Erreur lors de la récupération de la queue hors ligne: $e');
+      debugPrint('Erreur lors de la récupération de la queue hors ligne: $e');
     }
     return [];
   }
@@ -261,7 +262,7 @@ class OfflineCacheService {
     try {
       await _storage.deleteSecureData(_offlineQueueKey);
     } catch (e) {
-      print('Erreur lors du vidage de la queue hors ligne: $e');
+      debugPrint('Erreur lors du vidage de la queue hors ligne: $e');
     }
   }
   
@@ -278,7 +279,7 @@ class OfflineCacheService {
         return DateTime.parse(cached);
       }
     } catch (e) {
-      print('Erreur lors de la récupération du timestamp de sync: $e');
+      debugPrint('Erreur lors de la récupération du timestamp de sync: $e');
     }
     return null;
   }
@@ -301,7 +302,7 @@ class OfflineCacheService {
         // Note: On garde les détails de manga car ils changent moins souvent
       }
     } catch (e) {
-      print('Erreur lors du nettoyage du cache expiré: $e');
+      debugPrint('Erreur lors du nettoyage du cache expiré: $e');
     }
   }
   
@@ -315,7 +316,7 @@ class OfflineCacheService {
       await _storage.deleteSecureData(_lastSyncKey);
       await _storage.deleteSecureData(_cacheMetadataKey);
     } catch (e) {
-      print('Erreur lors du nettoyage complet du cache: $e');
+      debugPrint('Erreur lors du nettoyage complet du cache: $e');
     }
   }
   
@@ -326,7 +327,7 @@ class OfflineCacheService {
       existing[cacheType] = timestamp.toIso8601String();
       await _storage.writeSecureData(_cacheMetadataKey, jsonEncode(existing));
     } catch (e) {
-      print('Erreur lors de la mise à jour des métadonnées: $e');
+      debugPrint('Erreur lors de la mise à jour des métadonnées: $e');
     }
   }
   
@@ -338,7 +339,7 @@ class OfflineCacheService {
         return Map<String, String>.from(jsonDecode(cached));
       }
     } catch (e) {
-      print('Erreur lors de la récupération des métadonnées: $e');
+      debugPrint('Erreur lors de la récupération des métadonnées: $e');
     }
     return {};
   }
@@ -365,7 +366,7 @@ class OfflineCacheService {
       // Nettoyer la page d'accueil si expirée
       if (await isCacheExpiredFor('homepage', maxHours: 6)) {
         await _storage.deleteSecureData(_homePageCacheKey);
-        print('Cache page d\'accueil nettoyé (expiré)');
+        debugPrint('Cache page d\'accueil nettoyé (expiré)');
       }
       
       // Nettoyer les recherches expirées
@@ -375,11 +376,11 @@ class OfflineCacheService {
           final query = key.replaceFirst('search_', '');
           final searchKey = '$_searchCacheKey${query.toLowerCase().replaceAll(' ', '_')}';
           await _storage.deleteSecureData(searchKey);
-          print('Cache recherche "$query" nettoyé (expiré)');
+          debugPrint('Cache recherche "$query" nettoyé (expiré)');
         }
       }
     } catch (e) {
-      print('Erreur lors du nettoyage des caches expirés: $e');
+      debugPrint('Erreur lors du nettoyage des caches expirés: $e');
     }
   }
   
@@ -399,7 +400,7 @@ class OfflineCacheService {
         'cache_entries': metadata.length,
       };
     } catch (e) {
-      print('Erreur lors de la récupération des stats: $e');
+      debugPrint('Erreur lors de la récupération des stats: $e');
       return {};
     }
   }

--- a/lib/core/services/sync_service.dart
+++ b/lib/core/services/sync_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:mangatracker/core/service_locator/service_locator.dart';
 import 'package:mangatracker/features/library/services/library.service.dart';
 import 'connectivity_service.dart';
@@ -46,16 +47,16 @@ class SyncService {
         return;
       }
       
-      print('🔄 Synchronisation de ${queue.length} actions hors ligne...');
+      debugPrint('🔄 Synchronisation de ${queue.length} actions hors ligne...');
       
       final List<Map<String, dynamic>> failedActions = [];
       
       for (final actionData in queue) {
         try {
           await _processOfflineAction(actionData);
-          print('✅ Action synchronisée: ${actionData['type']} pour manga ${actionData['muId']}');
+          debugPrint('✅ Action synchronisée: ${actionData['type']} pour manga ${actionData['muId']}');
         } catch (e) {
-          print('❌ Erreur lors de la synchronisation: $e');
+          debugPrint('❌ Erreur lors de la synchronisation: $e');
           failedActions.add(actionData);
         }
       }
@@ -66,15 +67,15 @@ class SyncService {
           'offline_queue',
           jsonEncode(failedActions),
         );
-        print('⚠️ ${failedActions.length} actions échouées, seront retentées plus tard');
+        debugPrint('⚠️ ${failedActions.length} actions échouées, seront retentées plus tard');
       } else {
         // Toutes les actions ont réussi, vider la queue
         await _cacheService.clearOfflineQueue();
-        print('✅ Toutes les actions ont été synchronisées');
+        debugPrint('✅ Toutes les actions ont été synchronisées');
       }
       
     } catch (e) {
-      print('❌ Erreur générale lors de la synchronisation: $e');
+      debugPrint('❌ Erreur générale lors de la synchronisation: $e');
     } finally {
       _isSyncing = false;
     }

--- a/lib/features/auth/services/auth.service.dart
+++ b/lib/features/auth/services/auth.service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
 import 'package:mangatracker/core/service_locator/service_locator.dart';
@@ -77,21 +78,36 @@ class AuthService {
   Future<bool> refreshAccessToken({String? token}) async {
     final refreshToken = token ?? await storageService.readSecureData('refreshToken');
     if (refreshToken == null || isTokenExpired(refreshToken)) {
+      debugPrint('⚠️ AuthService: Refresh token est null ou expiré');
       return false;
     }
 
-    final url = Uri.https(dotenv.env['MT_API_URL']!, '/auth/refresh');
-    final res = await http.post(url, headers: {
-      HttpHeaders.authorizationHeader: 'Bearer $refreshToken',
-    });
+    try {
+      final url = Uri.https(dotenv.env['MT_API_URL']!, '/auth/refresh');
+      final res = await http.post(url, headers: {
+        HttpHeaders.authorizationHeader: 'Bearer $refreshToken',
+      });
 
-    if (res.statusCode == HttpStatus.created) {
-      final data = jsonDecode(res.body);
-      await storageService.writeSecureData('accessToken', data['accessToken']);
-      return true;
+      if (res.statusCode == HttpStatus.created) {
+        final data = jsonDecode(res.body);
+        await storageService.writeSecureData('accessToken', data['accessToken']);
+        
+        // Si le backend renvoie un nouveau refreshToken (rotation), le sauvegarder
+        if (data.containsKey('refreshToken') && data['refreshToken'] != null) {
+          debugPrint('✅ AuthService: Nouveau refreshToken reçu, sauvegarde...');
+          await storageService.writeSecureData('refreshToken', data['refreshToken']);
+        }
+        
+        debugPrint('✅ AuthService: Access token rafraîchi avec succès');
+        return true;
+      } else {
+        debugPrint('⚠️ AuthService: Échec du refresh - Status: ${res.statusCode}, Body: ${res.body}');
+        return false;
+      }
+    } catch (e) {
+      debugPrint('❌ AuthService: Erreur lors du refresh: $e');
+      return false;
     }
-
-    return false;
   }
 
   String _decodeBase64(String str) {

--- a/lib/features/home/bloc/homepage_bloc.dart
+++ b/lib/features/home/bloc/homepage_bloc.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:bloc/bloc.dart';
+import 'package:flutter/foundation.dart';
 import 'package:mangatracker/core/service_locator/service_locator.dart';
 import 'package:mangatracker/core/services/cache_helper_service.dart';
 import 'package:mangatracker/core/services/connectivity_service.dart';
@@ -49,7 +50,7 @@ class HomePageBloc extends Bloc<HomePageEvent, HomePageState> {
 
   /// Charge la page d'accueil complète
   Future<void> _onLoadHomePage(LoadHomePage event, Emitter<HomePageState> emit) async {
-    print('🔄 HomePageBloc: Chargement de la page d\'accueil...');
+    debugPrint('🔄 HomePageBloc: Chargement de la page d\'accueil...');
     emit(const HomePageLoading());
     
     try {
@@ -73,8 +74,18 @@ class HomePageBloc extends Bloc<HomePageEvent, HomePageState> {
         pendingActions: pendingActions,
       ));
     } catch (e) {
+      // Ne pas traiter InvalidCredentialsException comme une erreur réseau
+      if (e.toString().contains('InvalidCredentialsException')) {
+        debugPrint('⚠️ HomePageBloc: Erreur d\'authentification');
+        emit(HomePageError(
+          message: 'Authentification requise',
+          isOffline: false,
+        ));
+        return;
+      }
+      
       // Erreur réseau détectée : on est offline
-      print('⚠️ Erreur de chargement, tentative de récupération depuis le cache...');
+      debugPrint('⚠️ Erreur de chargement, tentative de récupération depuis le cache...');
       
       try {
         // Récupérer les caches séparés pour chaque type de manga
@@ -88,7 +99,7 @@ class HomePageBloc extends Bloc<HomePageEvent, HomePageState> {
             (cachedNew != null && cachedNew.isNotEmpty) ||
             (cachedTrending != null && cachedTrending.isNotEmpty)) {
           final pendingActions = await _getPendingActionsCount();
-          print('✅ Données chargées depuis le cache (mode offline) - Popular: ${cachedPopular?.length ?? 0}, New: ${cachedNew?.length ?? 0}, Trending: ${cachedTrending?.length ?? 0}, Pending: $pendingActions');
+          debugPrint('✅ Données chargées depuis le cache (mode offline) - Popular: ${cachedPopular?.length ?? 0}, New: ${cachedNew?.length ?? 0}, Trending: ${cachedTrending?.length ?? 0}, Pending: $pendingActions');
           
           emit(HomePageLoaded(
             popularMangas: cachedPopular ?? [],

--- a/lib/features/home/views/homepage_bloc_view.dart
+++ b/lib/features/home/views/homepage_bloc_view.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mangatracker/core/service_locator/service_locator.dart';
@@ -27,7 +28,7 @@ class _HomePageBlocViewState extends State<HomePageBlocView> {
   @override
   void initState() {
     super.initState();
-    print('🏠 HomePageBlocView initialisée - Utilisation du BLoC !');
+    debugPrint('🏠 HomePageBlocView initialisée - Utilisation du BLoC !');
     // Charger la page d'accueil au démarrage
     _homePageBloc.add(const LoadHomePage());
   }

--- a/lib/features/library/bloc/library_bloc.dart
+++ b/lib/features/library/bloc/library_bloc.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:bloc/bloc.dart';
+import 'package:flutter/foundation.dart';
 import 'package:mangatracker/core/service_locator/service_locator.dart';
 import 'package:mangatracker/core/services/cache_helper_service.dart';
 import 'package:mangatracker/core/services/connectivity_service.dart';
@@ -51,11 +52,11 @@ class LibraryBloc extends Bloc<LibraryEvent, LibraryState> {
 
   /// Charge la bibliothèque
   Future<void> _onLoadLibrary(LoadLibrary event, Emitter<LibraryState> emit) async {
-    print('🔄 LibraryBloc: Début du chargement de la bibliothèque...');
+    debugPrint('🔄 LibraryBloc: Début du chargement de la bibliothèque...');
     emit(const LibraryLoading());
     
     try {
-      print('🔄 LibraryBloc: Tentative de chargement depuis le réseau...');
+      debugPrint('🔄 LibraryBloc: Tentative de chargement depuis le réseau...');
       final mangas = await _cacheHelper.loadLibraryData(
         networkCall: () => _libraryService.getUserSavedMangas(),
       );
@@ -63,36 +64,46 @@ class LibraryBloc extends Bloc<LibraryEvent, LibraryState> {
       final pendingActions = await _getPendingActionsCount();
       
       // Si aucune erreur, on est online
-      print('✅ LibraryBloc: Données chargées depuis le réseau - ${mangas.length} mangas, $pendingActions actions en attente');
+      debugPrint('✅ LibraryBloc: Données chargées depuis le réseau - ${mangas.length} mangas, $pendingActions actions en attente');
       emit(LibraryLoaded(
         mangas: mangas,
         isOffline: false,
         pendingActions: pendingActions,
       ));
     } catch (e) {
+      // Ne pas traiter InvalidCredentialsException comme une erreur réseau
+      if (e.toString().contains('InvalidCredentialsException')) {
+        debugPrint('⚠️ LibraryBloc: Erreur d\'authentification, redirection vers login');
+        emit(LibraryError(
+          message: 'Authentification requise',
+          isOffline: false,
+        ));
+        return;
+      }
+      
       // Erreur réseau détectée : on est offline
-      print('⚠️ LibraryBloc: Erreur de chargement de la bibliothèque: $e');
-      print('⚠️ LibraryBloc: Tentative de récupération depuis le cache...');
+      debugPrint('⚠️ LibraryBloc: Erreur de chargement de la bibliothèque: $e');
+      debugPrint('⚠️ LibraryBloc: Tentative de récupération depuis le cache...');
       
       try {
         final cachedMangas = await _cacheHelper.getCachedLibrary();
         if (cachedMangas != null && cachedMangas.isNotEmpty) {
           final pendingActions = await _getPendingActionsCount();
-          print('✅ LibraryBloc: Données de la bibliothèque chargées depuis le cache (mode offline) - ${cachedMangas.length} mangas, $pendingActions actions en attente');
+          debugPrint('✅ LibraryBloc: Données de la bibliothèque chargées depuis le cache (mode offline) - ${cachedMangas.length} mangas, $pendingActions actions en attente');
           emit(LibraryLoaded(
             mangas: cachedMangas,
             isOffline: true,
             pendingActions: pendingActions,
           ));
         } else {
-          print('❌ LibraryBloc: Aucune donnée en cache disponible');
+          debugPrint('❌ LibraryBloc: Aucune donnée en cache disponible');
           emit(LibraryError(
             message: e.toString(),
             isOffline: true,
           ));
         }
       } catch (cacheError) {
-        print('❌ LibraryBloc: Erreur lors de la récupération du cache: $cacheError');
+        debugPrint('❌ LibraryBloc: Erreur lors de la récupération du cache: $cacheError');
         emit(LibraryError(
           message: e.toString(),
           isOffline: true,
@@ -319,9 +330,9 @@ class LibraryBloc extends Bloc<LibraryEvent, LibraryState> {
     try {
       final isConnected = await _connectivityService.checkConnectivity();
       // Cette information sera utilisée lors du premier chargement
-      print('🔍 État initial de connectivité: ${isConnected ? "Connecté" : "Hors ligne"}');
+      debugPrint('🔍 État initial de connectivité: ${isConnected ? "Connecté" : "Hors ligne"}');
     } catch (e) {
-      print('⚠️ Erreur lors de la vérification de connectivité: $e');
+      debugPrint('⚠️ Erreur lors de la vérification de connectivité: $e');
     }
   }
 }

--- a/lib/features/library/views/library_bloc_view.dart
+++ b/lib/features/library/views/library_bloc_view.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mangatracker/core/service_locator/service_locator.dart';
@@ -30,7 +31,7 @@ class _LibraryBlocViewState extends State<LibraryBlocView> {
   @override
   void initState() {
     super.initState();
-    print('📚 LibraryBlocView initialisée - Utilisation du BLoC !');
+    debugPrint('📚 LibraryBlocView initialisée - Utilisation du BLoC !');
     // Charger la bibliothèque au démarrage
     _libraryBloc.add(const LoadLibrary());
   }
@@ -207,7 +208,7 @@ class _LibraryBlocViewState extends State<LibraryBlocView> {
 
   Widget _buildLibraryContent(LibraryLoaded state) {
     // Debug : afficher l'état offline
-    print('📚 LibraryBlocView: isOffline=${state.isOffline}, pendingActions=${state.pendingActions}, mangas=${state.mangas.length}');
+    debugPrint('📚 LibraryBlocView: isOffline=${state.isOffline}, pendingActions=${state.pendingActions}, mangas=${state.mangas.length}');
     
     return Column(
       children: [

--- a/lib/features/manga/bloc/detail_bloc.dart
+++ b/lib/features/manga/bloc/detail_bloc.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:bloc/bloc.dart';
+import 'package:flutter/foundation.dart';
 import 'package:mangatracker/core/service_locator/service_locator.dart';
 import 'package:mangatracker/core/services/cache_helper_service.dart';
 import 'package:mangatracker/core/services/connectivity_service.dart';
@@ -52,7 +53,7 @@ class DetailBloc extends Bloc<DetailEvent, DetailState> {
 
   /// Charge les détails d'un manga
   Future<void> _onLoadMangaDetail(LoadMangaDetail event, Emitter<DetailState> emit) async {
-    print('🔄 DetailBloc: Chargement du manga ${event.muId}...');
+    debugPrint('🔄 DetailBloc: Chargement du manga ${event.muId}...');
     emit(const DetailLoading());
     _currentMuId = event.muId;
     
@@ -78,12 +79,12 @@ class DetailBloc extends Bloc<DetailEvent, DetailState> {
             readChaptersCount: readChaptersCount >= 0 ? readChaptersCount.toInt() : null,
             readingStatus: libraryStatus,
           );
-          print('📚 DetailBloc: Manga trouvé dans la bibliothèque avec statut: ${libraryStatus.name} et ${readChaptersCount} chapitres lus');
+          debugPrint('📚 DetailBloc: Manga trouvé dans la bibliothèque avec statut: ${libraryStatus.name} et ${readChaptersCount} chapitres lus');
         } else {
-          print('📚 DetailBloc: Manga non trouvé dans la bibliothèque');
+          debugPrint('📚 DetailBloc: Manga non trouvé dans la bibliothèque');
         }
       } catch (e) {
-        print('⚠️ DetailBloc: Erreur lors de la récupération du statut: $e');
+        debugPrint('⚠️ DetailBloc: Erreur lors de la récupération du statut: $e');
         // Continuer avec les détails de base si la récupération du statut échoue
       }
       
@@ -94,13 +95,23 @@ class DetailBloc extends Bloc<DetailEvent, DetailState> {
         pendingActions: pendingActions,
       ));
     } catch (e) {
+      // Ne pas traiter InvalidCredentialsException comme une erreur réseau
+      if (e.toString().contains('InvalidCredentialsException')) {
+        debugPrint('⚠️ DetailBloc: Erreur d\'authentification');
+        emit(DetailError(
+          message: 'Authentification requise',
+          isOffline: false,
+        ));
+        return;
+      }
+      
       // Erreur réseau détectée : on est offline
-      print('⚠️ Erreur de chargement du manga, tentative de récupération depuis le cache...');
+      debugPrint('⚠️ Erreur de chargement du manga, tentative de récupération depuis le cache...');
       
       try {
         final cachedMangaDetail = await _cacheHelper.getCachedMangaDetail(event.muId);
         if (cachedMangaDetail != null) {
-          print('✅ Données du manga chargées depuis le cache (mode offline)');
+          debugPrint('✅ Données du manga chargées depuis le cache (mode offline)');
           emit(DetailLoaded(
             mangaDetail: cachedMangaDetail,
             isOffline: true,
@@ -144,12 +155,12 @@ class DetailBloc extends Bloc<DetailEvent, DetailState> {
     ));
     
     try {
-      print('📚 DetailBloc: Ajout du manga ${event.muId} à la bibliothèque...');
+      debugPrint('📚 DetailBloc: Ajout du manga ${event.muId} à la bibliothèque...');
       final success = await _libraryService.addMangaToLibrary(event.muId);
       
       if (success) {
         // Mettre à jour l'état local sans recharger
-        print('✅ DetailBloc: Manga ajouté, mise à jour locale de l\'état...');
+        debugPrint('✅ DetailBloc: Manga ajouté, mise à jour locale de l\'état...');
         final updatedMangaDetail = _copyMangaDetail(
           currentState.mangaDetail,
           inLibrary: true,
@@ -203,12 +214,12 @@ class DetailBloc extends Bloc<DetailEvent, DetailState> {
     ));
     
     try {
-      print('🗑️ DetailBloc: Retrait du manga ${event.muId} de la bibliothèque...');
+      debugPrint('🗑️ DetailBloc: Retrait du manga ${event.muId} de la bibliothèque...');
       final success = await _libraryService.removeMangaFromLibrary(event.muId);
       
       if (success) {
         // Mettre à jour l'état local sans recharger
-        print('✅ DetailBloc: Manga retiré, mise à jour locale de l\'état...');
+        debugPrint('✅ DetailBloc: Manga retiré, mise à jour locale de l\'état...');
         final updatedMangaDetail = _copyMangaDetail(
           currentState.mangaDetail,
           inLibrary: false,
@@ -262,12 +273,12 @@ class DetailBloc extends Bloc<DetailEvent, DetailState> {
     ));
     
     try {
-      print('🔄 DetailBloc: Mise à jour du statut du manga $_currentMuId vers ${event.status.name}...');
+      debugPrint('🔄 DetailBloc: Mise à jour du statut du manga $_currentMuId vers ${event.status.name}...');
       final success = await _libraryService.updateMangaStatus(_currentMuId!, event.status);
       
       if (success) {
         // Mettre à jour l'état local sans recharger
-        print('✅ DetailBloc: Statut mis à jour, mise à jour locale de l\'état...');
+        debugPrint('✅ DetailBloc: Statut mis à jour, mise à jour locale de l\'état...');
         final updatedMangaDetail = _copyMangaDetail(
           currentState.mangaDetail,
           inLibrary: true,
@@ -306,7 +317,7 @@ class DetailBloc extends Bloc<DetailEvent, DetailState> {
 
   /// Sauvegarde la progression de lecture
   Future<void> _onSaveChapterProgress(SaveChapterProgress event, Emitter<DetailState> emit) async {
-    print('🔄 DetailBloc: Sauvegarde du chapitre ${event.readChapters} pour manga ${event.muId}...');
+    debugPrint('🔄 DetailBloc: Sauvegarde du chapitre ${event.readChapters} pour manga ${event.muId}...');
     if (state is! DetailLoaded) return;
     
     final currentState = state as DetailLoaded;
@@ -317,7 +328,7 @@ class DetailBloc extends Bloc<DetailEvent, DetailState> {
     try {
       // Si on décoche tous les chapitres (0 chapitres lus), retirer de la bibliothèque
       if (event.readChapters == 0 && currentState.mangaDetail.inLibrary) {
-        print('🗑️ Aucun chapitre lu, retrait automatique de la bibliothèque...');
+        debugPrint('🗑️ Aucun chapitre lu, retrait automatique de la bibliothèque...');
         final removeSuccess = await _libraryService.removeMangaFromLibrary(event.muId);
         if (removeSuccess) {
           final updatedMangaDetail = _copyMangaDetail(
@@ -334,7 +345,7 @@ class DetailBloc extends Bloc<DetailEvent, DetailState> {
             isOffline: isOffline,
             pendingActions: pendingActions,
           ));
-          print('✅ Manga retiré de la bibliothèque');
+          debugPrint('✅ Manga retiré de la bibliothèque');
         }
         return;
       }
@@ -342,7 +353,7 @@ class DetailBloc extends Bloc<DetailEvent, DetailState> {
       // Si le manga n'est pas dans la bibliothèque, l'ajouter d'abord
       bool wasAddedToLibrary = false;
       if (!currentState.mangaDetail.inLibrary) {
-        print('📚 Le manga n\'est pas dans la bibliothèque, ajout automatique...');
+        debugPrint('📚 Le manga n\'est pas dans la bibliothèque, ajout automatique...');
         final addSuccess = await _libraryService.addMangaToLibrary(event.muId);
         // Si offline et addSuccess, ça veut dire que c'est en queue
         if (!addSuccess && !isOffline) {
@@ -354,15 +365,15 @@ class DetailBloc extends Bloc<DetailEvent, DetailState> {
           return;
         }
         wasAddedToLibrary = true;
-        print('✅ DetailBloc: Manga ajouté automatiquement à la bibliothèque');
+        debugPrint('✅ DetailBloc: Manga ajouté automatiquement à la bibliothèque');
       }
       
-      print('🔍 Sauvegarde du chapitre dans le service...');
+      debugPrint('🔍 Sauvegarde du chapitre dans le service...');
       final success = await _libraryService.saveChapterProgress(event.muId, event.readChapters);
-      print('🔍 Résultat de la sauvegarde: $success');
+      debugPrint('🔍 Résultat de la sauvegarde: $success');
       
       if (success) {
-        print('🔍 Détermination du statut de lecture...');
+        debugPrint('🔍 Détermination du statut de lecture...');
         // Déterminer le statut de lecture automatiquement
         ReadingStatus newStatus = _determineReadingStatus(
           currentReadingStatus: currentState.mangaDetail.readingStatus,
@@ -370,13 +381,13 @@ class DetailBloc extends Bloc<DetailEvent, DetailState> {
           totalChapters: currentState.mangaDetail.totalChapters,
           isCompleted: currentState.mangaDetail.isCompleted,
         );
-        print('🔍 Nouveau statut déterminé: ${newStatus.name}');
+        debugPrint('🔍 Nouveau statut déterminé: ${newStatus.name}');
         
         // Si le statut a changé, mettre à jour également le statut (uniquement si dans la bibliothèque)
         final isNowInLibrary = currentState.mangaDetail.inLibrary || wasAddedToLibrary;
-        print('🔍 isNowInLibrary: $isNowInLibrary, statut actuel: ${currentState.mangaDetail.readingStatus}, nouveau statut: ${newStatus.name}');
+          debugPrint('🔍 isNowInLibrary: $isNowInLibrary, statut actuel: ${currentState.mangaDetail.readingStatus}, nouveau statut: ${newStatus.name}');
         if (newStatus != currentState.mangaDetail.readingStatus && isNowInLibrary) {
-          print('🔄 Mise à jour automatique du statut vers: ${newStatus.name}');
+          debugPrint('🔄 Mise à jour automatique du statut vers: ${newStatus.name}');
           await _libraryService.updateMangaStatus(event.muId, newStatus);
         }
         
@@ -391,7 +402,7 @@ class DetailBloc extends Bloc<DetailEvent, DetailState> {
         }
         
         // Mettre à jour l'état local sans recharger
-        print('✅ DetailBloc: Chapitre sauvegardé, mise à jour locale...');
+        debugPrint('✅ DetailBloc: Chapitre sauvegardé, mise à jour locale...');
         final updatedMangaDetail = _copyMangaDetail(
           currentState.mangaDetail,
           inLibrary: isNowInLibrary,
@@ -434,27 +445,27 @@ class DetailBloc extends Bloc<DetailEvent, DetailState> {
     required int totalChapters,
     bool? isCompleted,
   }) {
-    print('🔍 _determineReadingStatus: readChapters=$readChapters, totalChapters=$totalChapters, isCompleted=$isCompleted');
+    debugPrint('🔍 _determineReadingStatus: readChapters=$readChapters, totalChapters=$totalChapters, isCompleted=$isCompleted');
     
     // Si tous les chapitres disponibles sont lus
     if (readChapters >= totalChapters && totalChapters > 0) {
       if (isCompleted == true) {
-        print('✅ Tous chapitres lus + manga terminé → completed');
+        debugPrint('✅ Tous chapitres lus + manga terminé → completed');
         return ReadingStatus.completed;
       } else {
-        print('✅ Tous chapitres lus + manga en cours → caughtUp');
+        debugPrint('✅ Tous chapitres lus + manga en cours → caughtUp');
         return ReadingStatus.caughtUp;
       }
     }
     
     // Si on a commencé à lire (au moins 1 chapitre)
     if (readChapters > 0) {
-      print('✅ Lecture en cours → reading');
+      debugPrint('✅ Lecture en cours → reading');
       return ReadingStatus.reading;
     }
     
     // Sinon, garder le statut actuel ou mettre "À lire plus tard" par défaut
-    print('✅ Aucun chapitre lu → readLater');
+    debugPrint('✅ Aucun chapitre lu → readLater');
     return currentReadingStatus ?? ReadingStatus.readLater;
   }
 

--- a/lib/features/manga/helpers/chapter_section.helper.dart
+++ b/lib/features/manga/helpers/chapter_section.helper.dart
@@ -1,0 +1,129 @@
+import '../dto/season_chapter.dto.dart';
+
+/// Helper pour calculer les sections de chapitres
+class ChapterSection {
+  final String title;
+  final int startChapter;
+  final int endChapter;
+  final List<int> chapterNumbers;
+
+  const ChapterSection({
+    required this.title,
+    required this.startChapter,
+    required this.endChapter,
+    required this.chapterNumbers,
+  });
+}
+
+class ChapterSectionHelper {
+  /// Calcule les sections de chapitres en fonction des saisons ou crée des sections de 100
+  static List<ChapterSection> calculateSections({
+    required int totalChapters,
+    List<SeasonChapter>? seasonChapters,
+    List<SeasonChapter>? bonusChapters,
+  }) {
+    final sections = <ChapterSection>[];
+
+    // Cas 1: Avec saisons
+    if (seasonChapters != null && seasonChapters.isNotEmpty) {
+      int currentChapter = 1;
+      
+      for (int i = 0; i < seasonChapters.length; i++) {
+        final season = seasonChapters[i];
+        int chapterCount = season.chapters;
+        
+        // Pour la dernière saison principale, vérifier s'il manque des chapitres
+        // (les bonus chapters ne sont pas inclus dans totalChapters)
+        if (i == seasonChapters.length - 1) {
+          // Calculer le total des saisons jusqu'à maintenant (y compris celle-ci)
+          final totalFromSeasons = seasonChapters.fold<int>(
+            0,
+            (sum, s) => sum + s.chapters,
+          );
+          
+          // Si le total des saisons est inférieur au total réel, ajouter les chapitres manquants à la dernière saison
+          if (totalFromSeasons < totalChapters) {
+            final missingChapters = totalChapters - totalFromSeasons;
+            chapterCount += missingChapters;
+          }
+        }
+        
+        final endChapter = currentChapter + chapterCount - 1;
+        final chapterNumbers = List.generate(
+          chapterCount,
+          (index) => currentChapter + index,
+        ).reversed.toList(); // Ordre décroissant
+        
+        sections.add(ChapterSection(
+          title: season.season,
+          startChapter: currentChapter,
+          endChapter: endChapter,
+          chapterNumbers: chapterNumbers,
+        ));
+        
+        currentChapter += chapterCount;
+      }
+      
+      // Ajouter les bonus chapters (séparés des saisons principales)
+      // Les bonus chapters sont numérotés à partir de totalChapters + 1
+      if (bonusChapters != null && bonusChapters.isNotEmpty) {
+        int bonusStartChapter = totalChapters + 1;
+        
+        for (final bonus in bonusChapters) {
+          final bonusEndChapter = bonusStartChapter + bonus.chapters - 1;
+          final chapterNumbers = List.generate(
+            bonus.chapters,
+            (index) => bonusStartChapter + index,
+          ).reversed.toList();
+          
+          sections.add(ChapterSection(
+            title: bonus.season,
+            startChapter: bonusStartChapter,
+            endChapter: bonusEndChapter,
+            chapterNumbers: chapterNumbers,
+          ));
+          
+          bonusStartChapter += bonus.chapters;
+        }
+      }
+    }
+    // Cas 2: Sans saisons mais >= 100 chapitres -> sections de 100
+    else if (totalChapters >= 100) {
+      for (int i = 0; i < totalChapters; i += 100) {
+        final startChapter = i + 1;
+        final endChapter = (i + 100 > totalChapters) ? totalChapters : i + 100;
+        final chapterCount = endChapter - startChapter + 1;
+        
+        final chapterNumbers = List.generate(
+          chapterCount,
+          (index) => startChapter + index,
+        ).reversed.toList();
+        
+        sections.add(ChapterSection(
+          title: 'Chapitres $startChapter-$endChapter',
+          startChapter: startChapter,
+          endChapter: endChapter,
+          chapterNumbers: chapterNumbers,
+        ));
+      }
+    }
+    // Cas 3: Sans saisons et < 100 chapitres -> pas de sections (affichage linéaire)
+    
+    return sections;
+  }
+  
+  /// Trouve la section contenant un chapitre donné
+  static String? findSectionForChapter(
+    int chapterNumber,
+    List<ChapterSection> sections,
+  ) {
+    for (final section in sections) {
+      if (chapterNumber >= section.startChapter && 
+          chapterNumber <= section.endChapter) {
+        return section.title;
+      }
+    }
+    return null;
+  }
+}
+

--- a/lib/features/manga/views/detail_bloc_view.dart
+++ b/lib/features/manga/views/detail_bloc_view.dart
@@ -1,4 +1,5 @@
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -60,7 +61,7 @@ class _DetailBlocViewState extends State<DetailBlocView> {
     return BlocProvider(
       create: (context) {
         final bloc = DetailBloc();
-        print('📖 DetailBlocView initialisée pour manga ${widget.muId} - Utilisation du BLoC !');
+        debugPrint('📖 DetailBlocView initialisée pour manga ${widget.muId} - Utilisation du BLoC !');
         // Charger les détails immédiatement après création
         bloc.add(LoadMangaDetail(widget.muId));
         return bloc;
@@ -250,55 +251,94 @@ class _DetailBlocViewContentState extends State<_DetailBlocViewContent> {
           child: Column(
             children: [
               // Header avec image et titre
-              Stack(
-                children: [
-                  SizedBox(
-                    width: double.infinity,
-                    height: 340,
-                    child: ImageHelper.loadMangaImage(
-                      widget.coverPath ?? manga.mediumCoverUrl,
-                      fit: BoxFit.cover,
-                    ),
-                  ),
-                  Container(
-                    width: double.infinity,
-                    height: 340,
-                    color: Colors.black.withValues(alpha: 0.4),
-                  ),
-                  Positioned(
-                    top: 70,
-                    left: 16,
-                    right: 16,
-                    child: AutoSizeText(
-                      parse(widget.mangaTitle ?? manga.title).documentElement?.text ?? '',
-                      textAlign: TextAlign.center,
-                      maxLines: 2,
-                      style: GoogleFonts.poppins(
-                        fontSize: 28,
-                        fontWeight: FontWeight.bold,
-                        color: Colors.white,
+              GestureDetector(
+                onTap: () {
+                  // Afficher l'image en plein écran
+                  showDialog(
+                    context: context,
+                    barrierColor: Colors.black87,
+                    builder: (context) => Dialog(
+                      backgroundColor: Colors.transparent,
+                      insetPadding: EdgeInsets.zero,
+                      child: Stack(
+                        children: [
+                          Center(
+                            child: InteractiveViewer(
+                              minScale: 0.5,
+                              maxScale: 3.0,
+                              child: ImageHelper.loadMangaImage(
+                                widget.coverPath ?? manga.largeCoverUrl ?? manga.mediumCoverUrl,
+                                fit: BoxFit.contain,
+                              ),
+                            ),
+                          ),
+                          Positioned(
+                            top: 40,
+                            right: 16,
+                            child: IconButton(
+                              icon: const Icon(Icons.close, color: Colors.white, size: 28),
+                              onPressed: () => Navigator.of(context).pop(),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                  ),
-                  if (manga.genres != null)
+                  );
+                },
+                child: Stack(
+                  children: [
+                    SizedBox(
+                      width: double.infinity,
+                      height: 340,
+                      child: ImageHelper.loadMangaImage(
+                        widget.coverPath ?? manga.mediumCoverUrl,
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                    Container(
+                      width: double.infinity,
+                      height: 340,
+                      color: Colors.black.withValues(alpha: 0.4),
+                    ),
                     Positioned(
-                      bottom: 14,
+                      top: 70,
                       left: 16,
-                      right: 14,
-                      child: SizedBox(
-                        height: 24,
-                        child: ListView(
-                          scrollDirection: Axis.horizontal,
-                          children: manga.genres!
-                              .map((g) => Padding(
-                                    padding: const EdgeInsets.only(right: 8),
-                                    child: MangaType(type: g),
-                                  ))
-                              .toList(),
+                      right: 16,
+                      child: IgnorePointer(
+                        child: AutoSizeText(
+                          parse(widget.mangaTitle ?? manga.title).documentElement?.text ?? '',
+                          textAlign: TextAlign.center,
+                          maxLines: 2,
+                          style: GoogleFonts.poppins(
+                            fontSize: 28,
+                            fontWeight: FontWeight.bold,
+                            color: Colors.white,
+                          ),
                         ),
                       ),
                     ),
-                ],
+                    if (manga.genres != null)
+                      Positioned(
+                        bottom: 14,
+                        left: 16,
+                        right: 14,
+                        child: IgnorePointer(
+                          child: SizedBox(
+                            height: 24,
+                            child: ListView(
+                              scrollDirection: Axis.horizontal,
+                              children: manga.genres!
+                                  .map((g) => Padding(
+                                        padding: const EdgeInsets.only(right: 8),
+                                        child: MangaType(type: g),
+                                      ))
+                                  .toList(),
+                            ),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
               ),
               // Détails du manga (LateDetailView)
               Expanded(

--- a/lib/features/manga/views/detail_bloc_view.dart
+++ b/lib/features/manga/views/detail_bloc_view.dart
@@ -313,6 +313,9 @@ class _DetailBlocViewContentState extends State<_DetailBlocViewContent> {
                   authors: manga.authors,
                   year: manga.year,
                   readChapters: readChapters,
+                  seasonChapters: manga.seasonChapters,
+                  bonusChapters: manga.bonusChapters,
+                  associated: manga.associated,
                   onReadCountChanged: (newCount) {
                     // Dispatcher l'événement au BLoC pour mise à jour réactive
                     context.read<DetailBloc>().add(SaveChapterProgress(widget.muId, newCount.toInt()));

--- a/lib/features/manga/views/detail_bloc_view.dart
+++ b/lib/features/manga/views/detail_bloc_view.dart
@@ -14,7 +14,6 @@ import 'package:mangatracker/features/manga/helpers/image.helper.dart';
 import 'package:mangatracker/features/manga/views/late_detail.view.dart';
 import 'package:mangatracker/features/manga/views/web_view.dart';
 import 'package:mangatracker/features/manga/widgets/manga_card.dart';
-import 'package:mangatracker/features/manga/widgets/manga_type_bubble.dart';
 import 'package:mangatracker/features/manga/services/manga.service.dart';
 import 'package:mangatracker/core/notifier/notifier.dart';
 import '../../reader/utils/chapter_link_resolver.dart';
@@ -259,28 +258,40 @@ class _DetailBlocViewContentState extends State<_DetailBlocViewContent> {
                     barrierColor: Colors.black87,
                     builder: (context) => Dialog(
                       backgroundColor: Colors.transparent,
-                      insetPadding: EdgeInsets.zero,
-                      child: Stack(
-                        children: [
-                          Center(
-                            child: InteractiveViewer(
-                              minScale: 0.5,
-                              maxScale: 3.0,
-                              child: ImageHelper.loadMangaImage(
-                                widget.coverPath ?? manga.largeCoverUrl ?? manga.mediumCoverUrl,
-                                fit: BoxFit.contain,
+                      insetPadding: const EdgeInsets.all(20),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(20),
+                        child: Stack(
+                          children: [
+                            Center(
+                              child: InteractiveViewer(
+                                minScale: 0.5,
+                                maxScale: 3.0,
+                                child: ImageHelper.loadMangaImage(
+                                  widget.coverPath ?? manga.largeCoverUrl ?? manga.mediumCoverUrl,
+                                  fit: BoxFit.contain,
+                                ),
                               ),
                             ),
-                          ),
-                          Positioned(
-                            top: 40,
-                            right: 16,
-                            child: IconButton(
-                              icon: const Icon(Icons.close, color: Colors.white, size: 28),
-                              onPressed: () => Navigator.of(context).pop(),
+                            Positioned(
+                              top: 10,
+                              right: 10,
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: Colors.black54,
+                                  shape: BoxShape.circle,
+                                ),
+                                child: IconButton(
+                                  icon: const Icon(Icons.close, color: Colors.white, size: 24),
+                                  onPressed: () => Navigator.of(context).pop(),
+                                ),
+                              ),
                             ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
                   );
@@ -317,22 +328,42 @@ class _DetailBlocViewContentState extends State<_DetailBlocViewContent> {
                         ),
                       ),
                     ),
-                    if (manga.genres != null)
+                    if (manga.genres != null && manga.genres!.isNotEmpty)
                       Positioned(
                         bottom: 14,
                         left: 16,
-                        right: 14,
+                        right: 16,
                         child: IgnorePointer(
-                          child: SizedBox(
-                            height: 24,
-                            child: ListView(
+                          child: Container(
+                            constraints: const BoxConstraints(maxHeight: 80),
+                            child: SingleChildScrollView(
                               scrollDirection: Axis.horizontal,
-                              children: manga.genres!
-                                  .map((g) => Padding(
-                                        padding: const EdgeInsets.only(right: 8),
-                                        child: MangaType(type: g),
-                                      ))
-                                  .toList(),
+                              child: Wrap(
+                                spacing: 8.0,
+                                runSpacing: 8.0,
+                                alignment: WrapAlignment.start,
+                                children: manga.genres!.map((genre) {
+                                  return Container(
+                                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                                    decoration: BoxDecoration(
+                                      color: Colors.white.withValues(alpha: 0.9),
+                                      borderRadius: BorderRadius.circular(12),
+                                      border: Border.all(
+                                        color: Colors.white.withValues(alpha: 0.3),
+                                        width: 1,
+                                      ),
+                                    ),
+                                    child: Text(
+                                      genre,
+                                      style: const TextStyle(
+                                        fontSize: 12,
+                                        fontWeight: FontWeight.w500,
+                                        color: Colors.black87,
+                                      ),
+                                    ),
+                                  );
+                                }).toList(),
+                              ),
                             ),
                           ),
                         ),
@@ -353,6 +384,7 @@ class _DetailBlocViewContentState extends State<_DetailBlocViewContent> {
                   authors: manga.authors,
                   year: manga.year,
                   readChapters: readChapters,
+                  genres: manga.genres,
                   seasonChapters: manga.seasonChapters,
                   bonusChapters: manga.bonusChapters,
                   associated: manga.associated,

--- a/lib/features/manga/views/detail_bloc_view.dart
+++ b/lib/features/manga/views/detail_bloc_view.dart
@@ -264,33 +264,42 @@ class _DetailBlocViewContentState extends State<_DetailBlocViewContent> {
                       ),
                       child: ClipRRect(
                         borderRadius: BorderRadius.circular(20),
-                        child: Stack(
-                          children: [
-                            Center(
-                              child: InteractiveViewer(
-                                minScale: 0.5,
-                                maxScale: 3.0,
-                                child: ImageHelper.loadMangaImage(
-                                  widget.coverPath ?? manga.largeCoverUrl ?? manga.mediumCoverUrl,
-                                  fit: BoxFit.contain,
+                         child: Container(
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(20),
+                            color: Colors.transparent,
+                          ),
+                          child: Stack(
+                            children: [
+                              Center(
+                                child: ClipRRect(
+                                  borderRadius: BorderRadius.circular(20),
+                                  child: InteractiveViewer(
+                                    minScale: 0.5,
+                                    maxScale: 3.0,
+                                    child: ImageHelper.loadMangaImage(
+                                      widget.coverPath ?? manga.largeCoverUrl ?? manga.mediumCoverUrl,
+                                      fit: BoxFit.contain,
+                                    ),
+                                  ),
                                 ),
                               ),
-                            ),
-                            Positioned(
-                              top: 10,
-                              right: 10,
-                              child: Container(
-                                decoration: BoxDecoration(
-                                  color: Colors.black54,
-                                  shape: BoxShape.circle,
-                                ),
-                                child: IconButton(
-                                  icon: const Icon(Icons.close, color: Colors.white, size: 24),
-                                  onPressed: () => Navigator.of(context).pop(),
+                              Positioned(
+                                top: 10,
+                                right: 10,
+                                child: Container(
+                                  decoration: BoxDecoration(
+                                    color: Colors.black54,
+                                    shape: BoxShape.circle,
+                                  ),
+                                  child: IconButton(
+                                    icon: const Icon(Icons.close, color: Colors.white, size: 24),
+                                    onPressed: () => Navigator.of(context).pop(),
+                                  ),
                                 ),
                               ),
-                            ),
-                          ],
+                            ],
+                          ),
                         ),
                       ),
                     ),
@@ -333,36 +342,40 @@ class _DetailBlocViewContentState extends State<_DetailBlocViewContent> {
                         bottom: 14,
                         left: 16,
                         right: 16,
-                        child: IgnorePointer(
-                          child: Container(
-                            constraints: const BoxConstraints(maxHeight: 80),
-                            child: SingleChildScrollView(
-                              scrollDirection: Axis.horizontal,
-                              child: Wrap(
-                                spacing: 8.0,
-                                runSpacing: 8.0,
-                                alignment: WrapAlignment.start,
-                                children: manga.genres!.map((genre) {
-                                  return Container(
-                                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                                    decoration: BoxDecoration(
-                                      color: Colors.white.withValues(alpha: 0.9),
-                                      borderRadius: BorderRadius.circular(12),
-                                      border: Border.all(
-                                        color: Colors.white.withValues(alpha: 0.3),
-                                        width: 1,
-                                      ),
-                                    ),
-                                    child: Text(
-                                      genre,
-                                      style: const TextStyle(
-                                        fontSize: 12,
-                                        fontWeight: FontWeight.w500,
-                                        color: Colors.black87,
-                                      ),
-                                    ),
-                                  );
-                                }).toList(),
+                        child: GestureDetector(
+                          onTap: () {}, // Empêcher le clic de remonter au GestureDetector parent
+                          child: SizedBox(
+                            height: 32,
+                            child: Scrollbar(
+                              thumbVisibility: true,
+                              thickness: 4,
+                              radius: const Radius.circular(2),
+                              child: ListView(
+                                scrollDirection: Axis.horizontal,
+                                children: manga.genres!
+                                    .map((g) => Padding(
+                                          padding: const EdgeInsets.only(right: 8),
+                                          child: Container(
+                                            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                                            decoration: BoxDecoration(
+                                              color: Colors.white.withValues(alpha: 0.9),
+                                              borderRadius: BorderRadius.circular(12),
+                                              border: Border.all(
+                                                color: Colors.white.withValues(alpha: 0.3),
+                                                width: 1,
+                                              ),
+                                            ),
+                                            child: Text(
+                                              g,
+                                              style: const TextStyle(
+                                                fontSize: 12,
+                                                fontWeight: FontWeight.w500,
+                                                color: Colors.black87,
+                                              ),
+                                            ),
+                                          ),
+                                        ))
+                                    .toList(),
                               ),
                             ),
                           ),

--- a/lib/features/manga/views/late_detail.view.dart
+++ b/lib/features/manga/views/late_detail.view.dart
@@ -26,6 +26,7 @@ class LateDetailView extends StatefulWidget {
   final List<AuthorDto>? authors;
   final String year;
   final num readChapters;
+  final List<String>? genres;
   final Function(num)? onReadCountChanged;
   final VoidCallback? onAddToLibrary;
   final VoidCallback? onRemoveFromLibrary;
@@ -45,6 +46,7 @@ class LateDetailView extends StatefulWidget {
     this.authors,
     required this.year,
     required this.readChapters,
+    this.genres,
     this.onReadCountChanged,
     this.onAddToLibrary,
     this.onRemoveFromLibrary,

--- a/lib/features/manga/views/late_detail.view.dart
+++ b/lib/features/manga/views/late_detail.view.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -97,7 +98,7 @@ class _LateDetailViewState extends State<LateDetailView> {
           _associatedExpanded = data['associatedExpanded'] ?? false;
         });
       } catch (e) {
-        print('Erreur lors du chargement de l\'état: $e');
+        debugPrint('Erreur lors du chargement de l\'état: $e');
         _initializeExpandedState();
       }
     } else {
@@ -320,40 +321,180 @@ class _LateDetailViewState extends State<LateDetailView> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // Titres, chapitres & note
+            // Informations principales (Chapitres, Note, Statut, Année) - Layout 2x2
             Padding(
-              padding: const EdgeInsets.symmetric(vertical: 8),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Column(
                 children: [
-                  Builder(
-                    builder: (context) {
-                      final l10n = AppLocalizations.of(context);
-                      return Text(
-                        l10n?.chaptersCount(widget.mangaTotalChapters?.toInt() ?? 0) ?? '${widget.mangaTotalChapters ?? 0} ${l10n?.chapters ?? "Chapitres"}',
-                        style: const TextStyle(
-                          fontSize: 15,
-                          color: Colors.grey,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      );
-                    },
-                  ),
-                  Wrap(
+                  // Première ligne : Chapitres et Note
+                  Row(
                     children: [
-                      Icon(Icons.star, color: Theme
-                          .of(context)
-                          .colorScheme
-                          .primary, size: 25),
-                      Text(
-                        widget.rating,
-                        style: GoogleFonts.poppins(
-                          textStyle: const TextStyle(fontSize: 20),
-                          fontWeight: FontWeight.bold,
-                          color: Theme
-                              .of(context)
-                              .colorScheme
-                              .primary,
+                      Expanded(
+                        child: Builder(
+                          builder: (context) {
+                            final l10n = AppLocalizations.of(context);
+                            return Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+                              decoration: BoxDecoration(
+                                color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+                                ),
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(
+                                    Icons.menu_book,
+                                    size: 18,
+                                    color: Theme.of(context).colorScheme.primary,
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Flexible(
+                                    child: Text(
+                                      l10n?.chaptersCount(widget.mangaTotalChapters?.toInt() ?? 0) ?? 
+                                      '${widget.mangaTotalChapters ?? 0} ${l10n?.chapters ?? "Chapitres"}',
+                                      style: TextStyle(
+                                        fontSize: 13,
+                                        fontWeight: FontWeight.w600,
+                                        color: Theme.of(context).colorScheme.onSurface,
+                                      ),
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.3),
+                            borderRadius: BorderRadius.circular(12),
+                            border: Border.all(
+                              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
+                            ),
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(
+                                Icons.star,
+                                size: 18,
+                                color: Theme.of(context).colorScheme.primary,
+                              ),
+                              const SizedBox(width: 6),
+                              Flexible(
+                                child: Text(
+                                  widget.rating,
+                                  style: GoogleFonts.poppins(
+                                    textStyle: TextStyle(
+                                      fontSize: 14,
+                                      fontWeight: FontWeight.w600,
+                                      color: Theme.of(context).colorScheme.primary,
+                                    ),
+                                  ),
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 10),
+                  // Deuxième ligne : Statut et Année
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Builder(
+                          builder: (context) {
+                            final l10n = AppLocalizations.of(context);
+                            final statusText = widget.isCompleted == true
+                                ? (l10n?.completed ?? "Terminé")
+                                : (l10n?.reading ?? "En cours");
+                            return Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+                              decoration: BoxDecoration(
+                                color: widget.isCompleted == true
+                                    ? Theme.of(context).colorScheme.tertiaryContainer.withValues(alpha: 0.3)
+                                    : Theme.of(context).colorScheme.secondaryContainer.withValues(alpha: 0.3),
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: widget.isCompleted == true
+                                      ? Theme.of(context).colorScheme.tertiary.withValues(alpha: 0.2)
+                                      : Theme.of(context).colorScheme.secondary.withValues(alpha: 0.2),
+                                ),
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Icon(
+                                    widget.isCompleted == true ? Icons.check_circle : Icons.access_time,
+                                    size: 18,
+                                    color: widget.isCompleted == true
+                                        ? Theme.of(context).colorScheme.tertiary
+                                        : Theme.of(context).colorScheme.secondary,
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Flexible(
+                                    child: Text(
+                                      statusText,
+                                      style: TextStyle(
+                                        fontSize: 13,
+                                        fontWeight: FontWeight.w600,
+                                        color: widget.isCompleted == true
+                                            ? Theme.of(context).colorScheme.onTertiaryContainer
+                                            : Theme.of(context).colorScheme.onSecondaryContainer,
+                                      ),
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+                            borderRadius: BorderRadius.circular(12),
+                            border: Border.all(
+                              color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+                            ),
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(
+                                Icons.calendar_today,
+                                size: 18,
+                                color: Theme.of(context).colorScheme.primary,
+                              ),
+                              const SizedBox(width: 8),
+                              Flexible(
+                                child: Text(
+                                  widget.year,
+                                  style: TextStyle(
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w600,
+                                    color: Theme.of(context).colorScheme.onSurface,
+                                  ),
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
                       ),
                     ],
@@ -362,99 +503,124 @@ class _LateDetailViewState extends State<LateDetailView> {
               ),
             ),
 
-            // Statut & Année sur la même ligne
-            Builder(
-              builder: (context) {
-                final l10n = AppLocalizations.of(context);
-                return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      Flexible(
-                        flex: 1,
-                        child: Text(
-                          '${l10n?.status ?? "Statut"} : ${widget.isCompleted == true
-                              ? (l10n?.completed ?? "Terminé")
-                              : (l10n?.reading ?? "En cours")}',
-                          textAlign: TextAlign.center,
-                          style: const TextStyle(fontWeight: FontWeight.w500),
-                        ),
-                      ),
-                      Flexible(
-                        flex: 1,
-                        child: Text(
-                          '${l10n?.year ?? "Année"} : ${widget.year}',
-                          textAlign: TextAlign.center,
-                          style: const TextStyle(fontWeight: FontWeight.w500),
-                        ),
-                      ),
-                    ],
-                  ),
-                );
-              },
-            ),
-
-            // Auteur & Artiste sur la même ligne
+            // Auteur & Artiste
             if (authors.isNotEmpty || artists.isNotEmpty)
               Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 4,
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    if (authors.isNotEmpty)
-                      Flexible(
-                        flex: 1,
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            Builder(
-                              builder: (context) {
-                                final l10n = AppLocalizations.of(context);
-                                return Text(
-                                  '${l10n?.author ?? "Auteur"} :',
-                                  style: const TextStyle(
-                                    fontSize: 14,
-                                    fontWeight: FontWeight.bold,
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: IntrinsicHeight(
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      if (authors.isNotEmpty)
+                        Expanded(
+                          child: Container(
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(
+                                color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+                              ),
+                            ),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  children: [
+                                    Icon(
+                                      Icons.person,
+                                      size: 16,
+                                      color: Theme.of(context).colorScheme.primary,
+                                    ),
+                                    const SizedBox(width: 6),
+                                    Builder(
+                                      builder: (context) {
+                                        final l10n = AppLocalizations.of(context);
+                                        return Text(
+                                          l10n?.author ?? "Auteur",
+                                          style: TextStyle(
+                                            fontSize: 12,
+                                            fontWeight: FontWeight.w600,
+                                            color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                                          ),
+                                        );
+                                      },
+                                    ),
+                                  ],
+                                ),
+                                const SizedBox(height: 8),
+                                ...authors.map((name) => Padding(
+                                  padding: const EdgeInsets.only(bottom: 4),
+                                  child: Text(
+                                    name,
+                                    style: TextStyle(
+                                      fontSize: 13,
+                                      fontWeight: FontWeight.w500,
+                                      color: Theme.of(context).colorScheme.onSurface,
+                                    ),
                                   ),
-                                );
-                              },
+                                )),
+                              ],
                             ),
-                            ...authors.map(
-                                  (n) => Text(n, textAlign: TextAlign.center),
-                            ),
-                          ],
+                          ),
                         ),
-                      ),
-                    if (artists.isNotEmpty)
-                      Flexible(
-                        flex: 1,
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            Builder(
-                              builder: (context) {
-                                final l10n = AppLocalizations.of(context);
-                                return Text(
-                                  '${l10n?.artist ?? "Artiste"} :',
-                                  style: const TextStyle(
-                                    fontSize: 14,
-                                    fontWeight: FontWeight.bold,
+                      if (authors.isNotEmpty && artists.isNotEmpty)
+                        const SizedBox(width: 10),
+                      if (artists.isNotEmpty)
+                        Expanded(
+                          child: Container(
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(
+                                color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+                              ),
+                            ),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  children: [
+                                    Icon(
+                                      Icons.palette,
+                                      size: 16,
+                                      color: Theme.of(context).colorScheme.primary,
+                                    ),
+                                    const SizedBox(width: 6),
+                                    Builder(
+                                      builder: (context) {
+                                        final l10n = AppLocalizations.of(context);
+                                        return Text(
+                                          l10n?.artist ?? "Artiste",
+                                          style: TextStyle(
+                                            fontSize: 12,
+                                            fontWeight: FontWeight.w600,
+                                            color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
+                                          ),
+                                        );
+                                      },
+                                    ),
+                                  ],
+                                ),
+                                const SizedBox(height: 8),
+                                ...artists.map((name) => Padding(
+                                  padding: const EdgeInsets.only(bottom: 4),
+                                  child: Text(
+                                    name,
+                                    style: TextStyle(
+                                      fontSize: 13,
+                                      fontWeight: FontWeight.w500,
+                                      color: Theme.of(context).colorScheme.onSurface,
+                                    ),
                                   ),
-                                );
-                              },
+                                )),
+                              ],
                             ),
-                            ...artists.map(
-                                  (n) => Text(n, textAlign: TextAlign.center),
-                            ),
-                          ],
+                          ),
                         ),
-                      ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
 
@@ -778,14 +944,8 @@ class _LateDetailViewState extends State<LateDetailView> {
                                             onTap: _isSaving
                                                 ? null
                                                 : () => handleSaveChapter(widget.muId, chapNum),
-                                            child: Container(
+                                            child: Padding(
                                               padding: const EdgeInsets.symmetric(vertical: 8),
-                                              decoration: BoxDecoration(
-                                                color: isRead
-                                                    ? Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.2)
-                                                    : Colors.transparent,
-                                                borderRadius: BorderRadius.circular(8),
-                                              ),
                                               child: RowChapter(
                                                 line: line,
                                                 chapter: chapNum.toString(),

--- a/lib/features/manga/views/late_detail.view.dart
+++ b/lib/features/manga/views/late_detail.view.dart
@@ -837,7 +837,7 @@ class _LateDetailViewState extends State<LateDetailView> {
                             ),
                           ),
                         ),
-                        const SizedBox(height: 12),
+                        const SizedBox(height: 8),
                         ...reversedSections.map<Widget>((section) {
                           // Utiliser l'état chargé ou false par défaut
                           final isExpanded = _isStateLoaded 
@@ -849,7 +849,7 @@ class _LateDetailViewState extends State<LateDetailView> {
                               .length;
                           
                           return Container(
-                            margin: const EdgeInsets.only(bottom: 8),
+                            margin: const EdgeInsets.only(bottom: 4),
                             decoration: BoxDecoration(
                               color: Theme.of(context).colorScheme.surface,
                               borderRadius: BorderRadius.circular(12),
@@ -871,7 +871,7 @@ class _LateDetailViewState extends State<LateDetailView> {
                             ),
                             child: ExpansionTile(
                               key: ValueKey('${section.title}_${isExpanded}'),
-                              tilePadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                              tilePadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
                               shape: const RoundedRectangleBorder(
                                 borderRadius: BorderRadius.all(Radius.circular(12)),
                               ),
@@ -956,7 +956,7 @@ class _LateDetailViewState extends State<LateDetailView> {
                                       return Padding(
                                         padding: const EdgeInsets.symmetric(
                                           horizontal: 16,
-                                          vertical: 3,
+                                          vertical: 0,
                                         ),
                                         child: Material(
                                           color: Colors.transparent,
@@ -966,7 +966,7 @@ class _LateDetailViewState extends State<LateDetailView> {
                                                 ? null
                                                 : () => handleSaveChapter(widget.muId, chapNum),
                                             child: Padding(
-                                              padding: const EdgeInsets.symmetric(vertical: 8),
+                                              padding: const EdgeInsets.symmetric(vertical: 0),
                                               child: RowChapter(
                                                 line: line,
                                                 chapter: chapNum.toString(),
@@ -1001,14 +1001,14 @@ class _LateDetailViewState extends State<LateDetailView> {
                             ),
                           ),
                         ),
-                        const SizedBox(height: 10),
+                        const SizedBox(height: 6),
                         Column(
                           children: List.generate(total, (i) => total - i).map((chapNum) {
                             final line = chapNum.toString().padLeft(2, '0');
                             final isRead = chapNum <= _currentReadCount!;
 
                             return Padding(
-                              padding: const EdgeInsets.symmetric(vertical: 4),
+                              padding: const EdgeInsets.symmetric(vertical: 2),
                               child: Material(
                                 color: Colors.white,
                                 borderRadius: BorderRadius.circular(12),
@@ -1020,11 +1020,14 @@ class _LateDetailViewState extends State<LateDetailView> {
                                   child: AnimatedScale(
                                     scale: _isSaving ? 1.0 : 1.0,
                                     duration: const Duration(milliseconds: 100),
-                                    child: RowChapter(
-                                      line: line,
-                                      chapter: chapNum.toString(),
-                                      read: isRead,
-                                      enabled: !_isSaving,
+                                    child: Padding(
+                                      padding: const EdgeInsets.symmetric(vertical: 4),
+                                      child: RowChapter(
+                                        line: line,
+                                        chapter: chapNum.toString(),
+                                        read: isRead,
+                                        enabled: !_isSaving,
+                                      ),
                                     ),
                                   ),
                                 ),

--- a/lib/features/manga/views/late_detail.view.dart
+++ b/lib/features/manga/views/late_detail.view.dart
@@ -374,10 +374,10 @@ class _LateDetailViewState extends State<LateDetailView> {
                         child: Container(
                           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
                           decoration: BoxDecoration(
-                            color: Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.3),
+                            color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
                             borderRadius: BorderRadius.circular(12),
                             border: Border.all(
-                              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
+                              color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
                             ),
                           ),
                           child: Row(
@@ -386,7 +386,7 @@ class _LateDetailViewState extends State<LateDetailView> {
                               Icon(
                                 Icons.star,
                                 size: 18,
-                                color: Theme.of(context).colorScheme.primary,
+                                color: Colors.red,
                               ),
                               const SizedBox(width: 6),
                               Flexible(
@@ -396,7 +396,7 @@ class _LateDetailViewState extends State<LateDetailView> {
                                     textStyle: TextStyle(
                                       fontSize: 14,
                                       fontWeight: FontWeight.w600,
-                                      color: Theme.of(context).colorScheme.primary,
+                                      color: Colors.red,
                                     ),
                                   ),
                                   overflow: TextOverflow.ellipsis,
@@ -419,41 +419,50 @@ class _LateDetailViewState extends State<LateDetailView> {
                             final statusText = widget.isCompleted == true
                                 ? (l10n?.completed ?? "Terminé")
                                 : (l10n?.reading ?? "En cours");
+                            final statusLabel = l10n?.status ?? "État";
                             return Container(
                               padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
                               decoration: BoxDecoration(
-                                color: widget.isCompleted == true
-                                    ? Theme.of(context).colorScheme.tertiaryContainer.withValues(alpha: 0.3)
-                                    : Theme.of(context).colorScheme.secondaryContainer.withValues(alpha: 0.3),
+                                color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
                                 borderRadius: BorderRadius.circular(12),
                                 border: Border.all(
-                                  color: widget.isCompleted == true
-                                      ? Theme.of(context).colorScheme.tertiary.withValues(alpha: 0.2)
-                                      : Theme.of(context).colorScheme.secondary.withValues(alpha: 0.2),
+                                  color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
                                 ),
                               ),
                               child: Row(
                                 mainAxisSize: MainAxisSize.min,
                                 children: [
                                   Icon(
-                                    widget.isCompleted == true ? Icons.check_circle : Icons.access_time,
+                                    Icons.info_outline,
                                     size: 18,
-                                    color: widget.isCompleted == true
-                                        ? Theme.of(context).colorScheme.tertiary
-                                        : Theme.of(context).colorScheme.secondary,
+                                    color: Colors.red,
                                   ),
                                   const SizedBox(width: 8),
                                   Flexible(
-                                    child: Text(
-                                      statusText,
-                                      style: TextStyle(
-                                        fontSize: 13,
-                                        fontWeight: FontWeight.w600,
-                                        color: widget.isCompleted == true
-                                            ? Theme.of(context).colorScheme.onTertiaryContainer
-                                            : Theme.of(context).colorScheme.onSecondaryContainer,
-                                      ),
+                                    child: RichText(
                                       overflow: TextOverflow.ellipsis,
+                                      text: TextSpan(
+                                        style: TextStyle(
+                                          fontSize: 13,
+                                          fontWeight: FontWeight.w600,
+                                          color: Theme.of(context).colorScheme.onSurface,
+                                        ),
+                                        children: [
+                                          TextSpan(
+                                            text: '$statusLabel : ',
+                                            style: TextStyle(
+                                              fontWeight: FontWeight.w500,
+                                            ),
+                                          ),
+                                          TextSpan(
+                                            text: statusText,
+                                            style: TextStyle(
+                                              color: Colors.red,
+                                              fontWeight: FontWeight.w600,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
                                     ),
                                   ),
                                 ],

--- a/lib/features/manga/views/late_detail.view.dart
+++ b/lib/features/manga/views/late_detail.view.dart
@@ -1,10 +1,14 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../core/notifier/notifier.dart';
 import '../../../core/service_locator/service_locator.dart';
 import '../../library/services/library.service.dart';
 import '../dto/author.dto.dart';
+import '../dto/season_chapter.dto.dart';
+import '../helpers/chapter_section.helper.dart';
 import 'row_chapter.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -24,6 +28,9 @@ class LateDetailView extends StatefulWidget {
   final Function(num)? onReadCountChanged;
   final VoidCallback? onAddToLibrary;
   final VoidCallback? onRemoveFromLibrary;
+  final List<SeasonChapter>? seasonChapters;
+  final List<SeasonChapter>? bonusChapters;
+  final List<String>? associated;
 
   const LateDetailView({
     super.key,
@@ -40,6 +47,9 @@ class LateDetailView extends StatefulWidget {
     this.onReadCountChanged,
     this.onAddToLibrary,
     this.onRemoveFromLibrary,
+    this.seasonChapters,
+    this.bonusChapters,
+    this.associated,
   });
 
   @override
@@ -53,11 +63,135 @@ class _LateDetailViewState extends State<LateDetailView> {
   final LibraryService _libraryService = getIt<LibraryService>();
   final Notifier _notifier = getIt<Notifier>();
   int? _pendingChapterUpdate; // Pour tracker la mise à jour en cours
+  
+  // État d'ouverture des sections
+  Map<String, bool> _expandedSections = {};
+  bool _associatedExpanded = false;
 
   @override
   void initState() {
     super.initState();
     _currentReadCount = widget.readChapters;
+    _loadExpandedState();
+  }
+  
+  Future<void> _loadExpandedState() async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = 'manga_${widget.muId}_expanded_seasons';
+    final jsonString = prefs.getString(key);
+    
+    if (jsonString != null) {
+      try {
+        final Map<String, dynamic> data = jsonDecode(jsonString);
+        final expandedList = (data['expandedSeasons'] as List?)
+            ?.map((e) => e.toString())
+            .toList() ?? [];
+        
+        setState(() {
+          // Initialiser toutes les sections comme fermées
+          _expandedSections = {};
+          // Marquer celles sauvegardées comme ouvertes
+          for (final season in expandedList) {
+            _expandedSections[season] = true;
+          }
+          _associatedExpanded = data['associatedExpanded'] ?? false;
+        });
+      } catch (e) {
+        print('Erreur lors du chargement de l\'état: $e');
+        _initializeExpandedState();
+      }
+    } else {
+      // Pas de sauvegarde, déterminer l'état initial
+      _initializeExpandedState();
+    }
+  }
+  
+  void _initializeExpandedState() {
+    final totalChapters = widget.mangaTotalChapters?.toInt() ?? 0;
+    final readChapters = widget.readChapters.toInt();
+    
+    // Calculer les sections
+    final sections = ChapterSectionHelper.calculateSections(
+      totalChapters: totalChapters,
+      seasonChapters: widget.seasonChapters,
+      bonusChapters: widget.bonusChapters,
+    );
+    
+    if (sections.isNotEmpty) {
+      // Trouver la section contenant le dernier chapitre lu
+      final currentSection = ChapterSectionHelper.findSectionForChapter(
+        readChapters > 0 ? readChapters : 1,
+        sections,
+      );
+      
+      setState(() {
+        _expandedSections = {};
+        
+        if (currentSection != null) {
+          // Ouvrir la section actuelle
+          _expandedSections[currentSection] = true;
+          
+          // Fermer les sections précédentes (si on est dans une saison supérieure)
+          final currentIndex = sections.indexWhere((s) => s.title == currentSection);
+          if (currentIndex > 0) {
+            // Fermer toutes les sections avant la section actuelle
+            for (int i = 0; i < currentIndex; i++) {
+              _expandedSections[sections[i].title] = false;
+            }
+          }
+        }
+      });
+    }
+  }
+  
+  Future<void> _saveExpandedState() async {
+    final prefs = await SharedPreferences.getInstance();
+    final key = 'manga_${widget.muId}_expanded_seasons';
+    
+    final expandedList = _expandedSections.entries
+        .where((e) => e.value)
+        .map((e) => e.key)
+        .toList();
+    
+    final data = {
+      'expandedSeasons': expandedList,
+      'associatedExpanded': _associatedExpanded,
+    };
+    
+    await prefs.setString(key, jsonEncode(data));
+  }
+  
+  void _handleSectionExpansion(String sectionTitle, bool isExpanded) {
+    setState(() {
+      _expandedSections[sectionTitle] = isExpanded;
+      
+      // Si on ouvre une section, fermer les sections plus récentes (qui sont au-dessus dans l'affichage inversé)
+      if (isExpanded) {
+        final sections = ChapterSectionHelper.calculateSections(
+          totalChapters: widget.mangaTotalChapters?.toInt() ?? 0,
+          seasonChapters: widget.seasonChapters,
+          bonusChapters: widget.bonusChapters,
+        );
+        final reversedSections = sections.reversed.toList();
+        
+        final currentIndex = reversedSections.indexWhere((s) => s.title == sectionTitle);
+        if (currentIndex != -1 && currentIndex > 0) {
+          // Fermer toutes les sections plus récentes (au-dessus dans l'affichage)
+          for (int i = 0; i < currentIndex; i++) {
+            _expandedSections[reversedSections[i].title] = false;
+          }
+        }
+      }
+      // Si on ferme une section, on ne fait rien de spécial
+    });
+    _saveExpandedState();
+  }
+  
+  void _handleAssociatedExpansion(bool isExpanded) {
+    setState(() {
+      _associatedExpanded = isExpanded;
+    });
+    _saveExpandedState();
   }
   
   @override
@@ -178,8 +312,6 @@ class _LateDetailViewState extends State<LateDetailView> {
     }
 
     final total = widget.mangaTotalChapters?.toInt() ?? 0;
-    final chapNumbers = List<int>.generate(total, (i) => i + 1)
-      ..sort((a, b) => b.compareTo(a)); // tri décroissant
 
     return Scrollbar(
       thumbVisibility: true,
@@ -328,6 +460,97 @@ class _LateDetailViewState extends State<LateDetailView> {
 
             const SizedBox(height: 8),
 
+            // Noms associés (ExpansionTile)
+            if (widget.associated != null && widget.associated!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.surface,
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(
+                      color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+                    ),
+                  ),
+                  child: ExpansionTile(
+                    tilePadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    shape: const RoundedRectangleBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(12)),
+                    ),
+                    collapsedShape: const RoundedRectangleBorder(
+                      borderRadius: BorderRadius.all(Radius.circular(12)),
+                    ),
+                    leading: Icon(
+                      Icons.translate,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                    title: Builder(
+                      builder: (context) {
+                        final l10n = AppLocalizations.of(context);
+                        return Text(
+                          l10n?.associatedNames ?? 'Noms associés',
+                          style: GoogleFonts.poppins(
+                            textStyle: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w600,
+                              color: Theme.of(context).colorScheme.onSurface,
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                    subtitle: Builder(
+                      builder: (context) {
+                        final l10n = AppLocalizations.of(context);
+                        final count = widget.associated!.length;
+                        return Text(
+                          l10n?.associatedNamesCount(count) ?? '$count ${count > 1 ? "noms" : "nom"}',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+                          ),
+                        );
+                      },
+                    ),
+                    initiallyExpanded: _associatedExpanded,
+                    onExpansionChanged: _handleAssociatedExpansion,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                        child: Wrap(
+                          spacing: 10.0,
+                          runSpacing: 10.0,
+                          alignment: WrapAlignment.start,
+                          children: widget.associated!.map((name) {
+                            return Container(
+                              decoration: BoxDecoration(
+                                color: Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.5),
+                                borderRadius: BorderRadius.circular(20),
+                                border: Border.all(
+                                  color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
+                                  width: 1,
+                                ),
+                              ),
+                              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+                              child: Text(
+                                name,
+                                style: TextStyle(
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w500,
+                                  color: Theme.of(context).colorScheme.onPrimaryContainer,
+                                ),
+                              ),
+                            );
+                          }).toList(),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+
+            const SizedBox(height: 8),
+
             // SYNOPSIS avec Voir plus / Voir moins
             if (widget.mangaDescription != null && widget.mangaDescription!.isNotEmpty)
               ...[
@@ -400,57 +623,238 @@ class _LateDetailViewState extends State<LateDetailView> {
               ],
             const SizedBox(height: 8),
 
+            // Sections de chapitres
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Builder(
-                    builder: (context) {
-                      final l10n = AppLocalizations.of(context);
-                      return Text(
-                        l10n?.chaptersCount(total) ?? '$total ${l10n?.chapters ?? "chapitres"}',
-                        style: GoogleFonts.poppins(
-                          textStyle: const TextStyle(
-                            fontSize: 18,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      );
-                    },
-                  ),
-                  const SizedBox(height: 10),
-                  Column(
-                    children: chapNumbers.map((chapNum) {
-                      final line = chapNum.toString().padLeft(2, '0');
-                      final isRead = chapNum <= _currentReadCount!;
-
-                      return Padding(
-                        padding: const EdgeInsets.symmetric(vertical: 4),
-                        child: Material(
-                          color: Colors.white, // couleur de fond de la ligne
-                          borderRadius: BorderRadius.circular(12),
-                          child: InkWell(
-                            borderRadius: BorderRadius.circular(12),
-                            onTap: _isSaving
-                                ? null
-                                : () => handleSaveChapter(widget.muId, chapNum),
-                            child: AnimatedScale(
-                              scale: _isSaving ? 1.0 : 1.0,
-                              duration: const Duration(milliseconds: 100),
-                              child: RowChapter(
-                                line: line,
-                                chapter: chapNum.toString(),
-                                read: isRead,
-                                enabled: !_isSaving,
-                              ),
+              child: Builder(
+                builder: (context) {
+                  final l10n = AppLocalizations.of(context);
+                  
+                  // Calculer les sections
+                  final sections = ChapterSectionHelper.calculateSections(
+                    totalChapters: total,
+                    seasonChapters: widget.seasonChapters,
+                    bonusChapters: widget.bonusChapters,
+                  );
+                  
+                  // Si on a des sections, les afficher avec ExpansionTile
+                  if (sections.isNotEmpty) {
+                    // Inverser l'ordre : la plus récente en haut
+                    final reversedSections = sections.reversed.toList();
+                    
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          l10n?.chaptersCount(total) ?? '$total ${l10n?.chapters ?? "chapitres"}',
+                          style: GoogleFonts.poppins(
+                            textStyle: const TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.w600,
                             ),
                           ),
                         ),
-                      );
-                    }).toList(),
-                  ),
-                ],
+                        const SizedBox(height: 12),
+                        ...reversedSections.map<Widget>((section) {
+                          final isExpanded = _expandedSections[section.title] ?? false;
+                          final chapterCount = section.endChapter - section.startChapter + 1;
+                          final readCount = section.chapterNumbers
+                              .where((n) => n <= _currentReadCount!)
+                              .length;
+                          
+                          return Container(
+                            margin: const EdgeInsets.only(bottom: 8),
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).colorScheme.surface,
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(
+                                color: isExpanded
+                                    ? Theme.of(context).colorScheme.primary.withValues(alpha: 0.3)
+                                    : Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
+                                width: isExpanded ? 1.5 : 1,
+                              ),
+                              boxShadow: isExpanded
+                                  ? [
+                                      BoxShadow(
+                                        color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.1),
+                                        blurRadius: 8,
+                                        offset: const Offset(0, 2),
+                                      ),
+                                    ]
+                                  : null,
+                            ),
+                            child: ExpansionTile(
+                              tilePadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                              shape: const RoundedRectangleBorder(
+                                borderRadius: BorderRadius.all(Radius.circular(12)),
+                              ),
+                              collapsedShape: const RoundedRectangleBorder(
+                                borderRadius: BorderRadius.all(Radius.circular(12)),
+                              ),
+                              leading: Container(
+                                padding: const EdgeInsets.all(8),
+                                decoration: BoxDecoration(
+                                  color: Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.3),
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                                child: Icon(
+                                  Icons.list_alt,
+                                  color: Theme.of(context).colorScheme.primary,
+                                  size: 20,
+                                ),
+                              ),
+                              title: Text(
+                                section.title,
+                                style: GoogleFonts.poppins(
+                                  textStyle: TextStyle(
+                                    fontSize: 15,
+                                    fontWeight: FontWeight.w600,
+                                    color: Theme.of(context).colorScheme.onSurface,
+                                  ),
+                                ),
+                              ),
+                              subtitle: Row(
+                                children: [
+                                  Icon(
+                                    Icons.numbers,
+                                    size: 14,
+                                    color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+                                  ),
+                                  const SizedBox(width: 4),
+                                  Text(
+                                    '${section.startChapter}-${section.endChapter}',
+                                    style: TextStyle(
+                                      fontSize: 12,
+                                      color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  Icon(
+                                    Icons.check_circle_outline,
+                                    size: 14,
+                                    color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+                                  ),
+                                  const SizedBox(width: 4),
+                                  Text(
+                                    '$readCount/$chapterCount',
+                                    style: TextStyle(
+                                      fontSize: 12,
+                                      color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              trailing: Icon(
+                                isExpanded ? Icons.expand_less : Icons.expand_more,
+                                color: Theme.of(context).colorScheme.primary,
+                              ),
+                              initiallyExpanded: isExpanded,
+                              onExpansionChanged: (expanded) {
+                                _handleSectionExpansion(section.title, expanded);
+                              },
+                              children: [
+                                Container(
+                                  decoration: BoxDecoration(
+                                    color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+                                    borderRadius: const BorderRadius.only(
+                                      bottomLeft: Radius.circular(12),
+                                      bottomRight: Radius.circular(12),
+                                    ),
+                                  ),
+                                  child: Column(
+                                    children: section.chapterNumbers.map((chapNum) {
+                                      final line = chapNum.toString().padLeft(2, '0');
+                                      final isRead = chapNum <= _currentReadCount!;
+
+                                      return Padding(
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: 16,
+                                          vertical: 3,
+                                        ),
+                                        child: Material(
+                                          color: Colors.transparent,
+                                          child: InkWell(
+                                            borderRadius: BorderRadius.circular(8),
+                                            onTap: _isSaving
+                                                ? null
+                                                : () => handleSaveChapter(widget.muId, chapNum),
+                                            child: Container(
+                                              padding: const EdgeInsets.symmetric(vertical: 8),
+                                              decoration: BoxDecoration(
+                                                color: isRead
+                                                    ? Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.2)
+                                                    : Colors.transparent,
+                                                borderRadius: BorderRadius.circular(8),
+                                              ),
+                                              child: RowChapter(
+                                                line: line,
+                                                chapter: chapNum.toString(),
+                                                read: isRead,
+                                                enabled: !_isSaving,
+                                              ),
+                                            ),
+                                          ),
+                                        ),
+                                      );
+                                    }).toList(),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                        }).toList(),
+                      ],
+                    );
+                  }
+                  // Sinon, affichage linéaire (cas < 100 chapitres sans saisons)
+                  else {
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          l10n?.chaptersCount(total) ?? '$total ${l10n?.chapters ?? "chapitres"}',
+                          style: GoogleFonts.poppins(
+                            textStyle: const TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 10),
+                        Column(
+                          children: List.generate(total, (i) => total - i).map((chapNum) {
+                            final line = chapNum.toString().padLeft(2, '0');
+                            final isRead = chapNum <= _currentReadCount!;
+
+                            return Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 4),
+                              child: Material(
+                                color: Colors.white,
+                                borderRadius: BorderRadius.circular(12),
+                                child: InkWell(
+                                  borderRadius: BorderRadius.circular(12),
+                                  onTap: _isSaving
+                                      ? null
+                                      : () => handleSaveChapter(widget.muId, chapNum),
+                                  child: AnimatedScale(
+                                    scale: _isSaving ? 1.0 : 1.0,
+                                    duration: const Duration(milliseconds: 100),
+                                    child: RowChapter(
+                                      line: line,
+                                      chapter: chapNum.toString(),
+                                      read: isRead,
+                                      enabled: !_isSaving,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            );
+                          }).toList(),
+                        ),
+                      ],
+                    );
+                  }
+                },
               ),
             ),
           ],

--- a/lib/features/manga/views/late_detail.view.dart
+++ b/lib/features/manga/views/late_detail.view.dart
@@ -70,6 +70,7 @@ class _LateDetailViewState extends State<LateDetailView> {
   // État d'ouverture des sections
   Map<String, bool> _expandedSections = {};
   bool _associatedExpanded = false;
+  bool _isStateLoaded = false;
 
   @override
   void initState() {
@@ -98,6 +99,7 @@ class _LateDetailViewState extends State<LateDetailView> {
             _expandedSections[season] = true;
           }
           _associatedExpanded = data['associatedExpanded'] ?? false;
+          _isStateLoaded = true;
         });
       } catch (e) {
         debugPrint('Erreur lors du chargement de l\'état: $e');
@@ -143,7 +145,11 @@ class _LateDetailViewState extends State<LateDetailView> {
             }
           }
         }
+        _isStateLoaded = true;
       });
+    } else {
+      _initializeExpandedState();
+      _isStateLoaded = true;
     }
   }
   
@@ -833,7 +839,10 @@ class _LateDetailViewState extends State<LateDetailView> {
                         ),
                         const SizedBox(height: 12),
                         ...reversedSections.map<Widget>((section) {
-                          final isExpanded = _expandedSections[section.title] ?? false;
+                          // Utiliser l'état chargé ou false par défaut
+                          final isExpanded = _isStateLoaded 
+                              ? (_expandedSections[section.title] ?? false)
+                              : false;
                           final chapterCount = section.endChapter - section.startChapter + 1;
                           final readCount = section.chapterNumbers
                               .where((n) => n <= _currentReadCount!)
@@ -861,6 +870,7 @@ class _LateDetailViewState extends State<LateDetailView> {
                                   : null,
                             ),
                             child: ExpansionTile(
+                              key: ValueKey('${section.title}_${isExpanded}'),
                               tilePadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                               shape: const RoundedRectangleBorder(
                                 borderRadius: BorderRadius.all(Radius.circular(12)),

--- a/lib/features/manga/views/row_chapter.dart
+++ b/lib/features/manga/views/row_chapter.dart
@@ -53,13 +53,20 @@ class RowChapter extends StatelessWidget {
                 child: SizedBox(
                   height: 50,
                   child: Align(
-                    alignment: Alignment.topLeft,
+                    alignment: Alignment.centerLeft,
                     child: Padding(
-                      padding: const EdgeInsets.only(top: 15, left: 30),
+                      padding: const EdgeInsets.only(left: 16),
                       child: Builder(
                         builder: (context) {
                           final l10n = AppLocalizations.of(context);
-                          return Text('${l10n?.chapter ?? "Chapter"} $chapter');
+                          return Text(
+                            l10n?.chapter ?? "Chapter",
+                            style: GoogleFonts.poppins(
+                              textStyle: const TextStyle(fontSize: 16),
+                              fontWeight: FontWeight.w400,
+                              color: Colors.grey[600],
+                            ),
+                          );
                         },
                       ),
                     ),

--- a/lib/features/manga/views/row_chapter.dart
+++ b/lib/features/manga/views/row_chapter.dart
@@ -27,7 +27,7 @@ class RowChapter extends StatelessWidget {
       opacity: enabled ? 1.0 : 0.5,
       child: Padding(
         padding: const EdgeInsets.only(
-            top: 10.0, bottom: 10.0, right: 10.0, left: 10.0),
+            top: 7.0, bottom: 7.0, right: 10.0, left: 10.0),
         child: Container(
           decoration: BoxDecoration(
             color: Colors.white,
@@ -36,7 +36,7 @@ class RowChapter extends StatelessWidget {
           child: Row(
             children: [
               SizedBox(
-                height: 60,
+                height: 50,
                 width: 80,
                 child: Align(
                   alignment: Alignment.center,
@@ -51,11 +51,11 @@ class RowChapter extends StatelessWidget {
               ),
               Expanded(
                 child: SizedBox(
-                  height: 60,
+                  height: 50,
                   child: Align(
                     alignment: Alignment.topLeft,
                     child: Padding(
-                      padding: const EdgeInsets.only(top: 20, left: 30),
+                      padding: const EdgeInsets.only(top: 15, left: 30),
                       child: Builder(
                         builder: (context) {
                           final l10n = AppLocalizations.of(context);
@@ -67,10 +67,10 @@ class RowChapter extends StatelessWidget {
                 ),
               ),
               SizedBox(
-                height: 60,
+                height: 50,
                 width: 50,
                 child: Padding(
-                  padding: const EdgeInsets.all(10),
+                  padding: const EdgeInsets.all(8),
                   child: read
                       ? Container(
                           height: 5,

--- a/lib/features/profile/services/user.service.dart
+++ b/lib/features/profile/services/user.service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart';
 import 'package:mangatracker/core/service_locator/service_locator.dart';
@@ -47,7 +48,7 @@ class UserService {
     } catch (e) {
       // Si erreur réseau et qu'on a un cache (même expiré), l'utiliser
       if (cachedInfo != null) {
-        print('Erreur réseau, utilisation du cache utilisateur: $e');
+        debugPrint('Erreur réseau, utilisation du cache utilisateur: $e');
         return cachedInfo;
       }
       rethrow;
@@ -66,7 +67,7 @@ class UserService {
       await _cacheService.cacheUserInformation(userInfo);
     } catch (e) {
       // Erreur silencieuse en arrière-plan
-      print('Erreur lors de la mise à jour en arrière-plan des infos utilisateur: $e');
+      debugPrint('Erreur lors de la mise à jour en arrière-plan des infos utilisateur: $e');
     }
   }
 
@@ -116,7 +117,7 @@ class UserService {
     try {
       await _cacheService.storage.deleteSecureData('cached_user_info');
     } catch (e) {
-      print('Erreur lors de l\'invalidation du cache utilisateur: $e');
+      debugPrint('Erreur lors de l\'invalidation du cache utilisateur: $e');
     }
   }
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -79,6 +79,8 @@
   "chapters": "Kapitel",
   "readChapters": "Gelesene Kapitel",
   "totalChapters": "Gesamtkapitel",
+  "associatedNames": "Zugehörige Namen",
+  "associatedNamesCount": "{count, plural, =0{Keine Namen} =1{{count} Name} other{{count} Namen}}",
   "saveProgress": "Fortschritt speichern",
   "description": "Beschreibung",
   "authors": "Autoren",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -79,6 +79,14 @@
   "chapters": "Chapters",
   "readChapters": "Read chapters",
   "totalChapters": "Total chapters",
+  "associatedNames": "Associated Names",
+  "@associatedNames": {
+    "description": "Title for the manga's associated names section"
+  },
+  "associatedNamesCount": "{count, plural, =0{No names} =1{{count} name} other{{count} names}}",
+  "@associatedNamesCount": {
+    "description": "Number of associated names"
+  },
   "saveProgress": "Save progress",
   "description": "Description",
   "authors": "Authors",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -79,6 +79,8 @@
   "chapters": "Capítulos",
   "readChapters": "Capítulos leídos",
   "totalChapters": "Total de capítulos",
+  "associatedNames": "Nombres asociados",
+  "associatedNamesCount": "{count, plural, =0{Sin nombres} =1{{count} nombre} other{{count} nombres}}",
   "saveProgress": "Guardar progreso",
   "description": "Descripción",
   "authors": "Autores",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -395,6 +395,15 @@
     "description": "Label pour le total de chapitres"
   },
   
+  "associatedNames": "Noms associés",
+  "@associatedNames": {
+    "description": "Titre pour la section des noms associés du manga"
+  },
+  "associatedNamesCount": "{count, plural, =0{Aucun nom} =1{{count} nom} other{{count} noms}}",
+  "@associatedNamesCount": {
+    "description": "Nombre de noms associés"
+  },
+  
   "saveProgress": "Enregistrer la progression",
   "@saveProgress": {
     "description": "Action pour enregistrer la progression"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -79,6 +79,8 @@
   "chapters": "章",
   "readChapters": "読んだ章",
   "totalChapters": "総章数",
+  "associatedNames": "関連する名前",
+  "associatedNamesCount": "{count, plural, =0{名前なし} =1{{count}名前} other{{count}名前}}",
   "saveProgress": "進捗を保存",
   "description": "説明",
   "authors": "著者",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -79,6 +79,8 @@
   "chapters": "챕터",
   "readChapters": "읽은 챕터",
   "totalChapters": "전체 챕터",
+  "associatedNames": "관련 이름",
+  "associatedNamesCount": "{count, plural, =0{이름 없음} =1{{count}개 이름} other{{count}개 이름}}",
   "saveProgress": "진행 상황 저장",
   "description": "설명",
   "authors": "작가",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -576,6 +576,18 @@ abstract class AppLocalizations {
   /// **'Total de chapitres'**
   String get totalChapters;
 
+  /// Titre pour la section des noms associés du manga
+  ///
+  /// In fr, this message translates to:
+  /// **'Noms associés'**
+  String get associatedNames;
+
+  /// Nombre de noms associés
+  ///
+  /// In fr, this message translates to:
+  /// **'{count, plural, =0{Aucun nom} =1{{count} nom} other{{count} noms}}'**
+  String associatedNamesCount(num count);
+
   /// Action pour enregistrer la progression
   ///
   /// In fr, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -255,6 +255,21 @@ class AppLocalizationsDe extends AppLocalizations {
   String get totalChapters => 'Gesamtkapitel';
 
   @override
+  String get associatedNames => 'Zugehörige Namen';
+
+  @override
+  String associatedNamesCount(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Namen',
+      one: '$count Name',
+      zero: 'Keine Namen',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get saveProgress => 'Fortschritt speichern';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -253,6 +253,21 @@ class AppLocalizationsEn extends AppLocalizations {
   String get totalChapters => 'Total chapters';
 
   @override
+  String get associatedNames => 'Associated Names';
+
+  @override
+  String associatedNamesCount(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count names',
+      one: '$count name',
+      zero: 'No names',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get saveProgress => 'Save progress';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -263,6 +263,21 @@ class AppLocalizationsEs extends AppLocalizations {
   String get totalChapters => 'Total de capítulos';
 
   @override
+  String get associatedNames => 'Nombres asociados';
+
+  @override
+  String associatedNamesCount(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count nombres',
+      one: '$count nombre',
+      zero: 'Sin nombres',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get saveProgress => 'Guardar progreso';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -258,6 +258,21 @@ class AppLocalizationsFr extends AppLocalizations {
   String get totalChapters => 'Total de chapitres';
 
   @override
+  String get associatedNames => 'Noms associés';
+
+  @override
+  String associatedNamesCount(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count noms',
+      one: '$count nom',
+      zero: 'Aucun nom',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get saveProgress => 'Enregistrer la progression';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -253,6 +253,21 @@ class AppLocalizationsJa extends AppLocalizations {
   String get totalChapters => '総章数';
 
   @override
+  String get associatedNames => '関連する名前';
+
+  @override
+  String associatedNamesCount(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count名前',
+      one: '$count名前',
+      zero: '名前なし',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get saveProgress => '進捗を保存';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -253,6 +253,21 @@ class AppLocalizationsKo extends AppLocalizations {
   String get totalChapters => '전체 챕터';
 
   @override
+  String get associatedNames => '관련 이름';
+
+  @override
+  String associatedNamesCount(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count개 이름',
+      one: '$count개 이름',
+      zero: '이름 없음',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get saveProgress => '진행 상황 저장';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -261,6 +261,21 @@ class AppLocalizationsPt extends AppLocalizations {
   String get totalChapters => 'Total de capítulos';
 
   @override
+  String get associatedNames => 'Nomes associados';
+
+  @override
+  String associatedNamesCount(num count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count nomes',
+      one: '$count nome',
+      zero: 'Nenhum nome',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get saveProgress => 'Salvar progresso';
 
   @override

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -79,6 +79,8 @@
   "chapters": "Capítulos",
   "readChapters": "Capítulos lidos",
   "totalChapters": "Total de capítulos",
+  "associatedNames": "Nomes associados",
+  "associatedNamesCount": "{count, plural, =0{Nenhum nome} =1{{count} nome} other{{count} nomes}}",
   "saveProgress": "Salvar progresso",
   "description": "Descrição",
   "authors": "Autores",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,11 +19,11 @@ Future<void> main() async {
   //
   if (kReleaseMode) {
     await dotenv.load(fileName: "assets/env/.env.production");
-    print('ENV loaded: ${dotenv.env}');
+    debugPrint('ENV loaded: ${dotenv.env}');
   } else {
 
     await dotenv.load(fileName: "assets/env/.env.development");
-    print('ENV loaded: ${dotenv.env}');
+    debugPrint('ENV loaded: ${dotenv.env}');
   }
 
   // Register all services

--- a/lib/stories/component/password_fields_strory.dart
+++ b/lib/stories/component/password_fields_strory.dart
@@ -1,4 +1,5 @@
 import 'package:dashbook/dashbook.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:mangatracker/core/components/auth_button.dart';
 import '../../../core/theme/app_theme.dart';
@@ -35,7 +36,7 @@ void addPasswordFieldsStory(Dashbook dashbook) {
                       AuthButton(
                           text: 'Valider',
                           onTap: () { final isValid = formKey.currentState?.validate() ?? false;
-                          print("Est valide $isValid");}
+                          debugPrint("Est valide $isValid");}
 
                       ),
                     ],

--- a/memory-bank/architecture.md
+++ b/memory-bank/architecture.md
@@ -257,6 +257,8 @@ Le mode offline est détecté via les **erreurs réseau** plutôt que la connect
 - `MangaRow` : Ligne de manga dans une liste
 - `FilterButton` : Bouton de filtre
 - `WelcomeHeader` : En-tête de bienvenue
+- `MangaType` : Widget pour afficher les genres/tags (utilisé dans les listes)
+- **Genres dans les détails** : Affichage des genres dans `LateDetailView` avec des `Chip` Material 3 stylisés en `Wrap`, placés après les informations principales
 
 ---
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -118,7 +118,7 @@
 |----------------|--------|---------|
 | Vue de connexion | ✔️ **Complété** | `LoginView` avec validation |
 | Page compte utilisateur | ✔️ **Complété** | `Profile` modernisée avec Material 3, cache intégré |
-| Page détail manga | ✔️ **Complété** | `DetailBlocView` avec toutes les fonctionnalités |
+| Page détail manga | ✔️ **Complété** | `DetailBlocView` avec toutes les fonctionnalités, genres affichés avec chips stylisés, image plein écran avec bordures arrondies |
 | Page tendances/nouveautés | ✔️ **Complété** | `HomePageBlocView` avec filtres |
 | Barre de navigation | ✔️ **Complété** | `BottomNavbar` avec PageView |
 | Thème sombre | 🔴 **À finaliser** | Code préparé, à activer |


### PR DESCRIPTION
# Amélioration de la page de détail d'un manga

Cette PR améliore significativement la page de détail d'un manga avec de nouvelles fonctionnalités et un design modernisé.

<!-- CHANGELOG:START -->
### ✨ Ajouts
- Organisation des chapitres par saisons avec sections repliables
- Affichage des noms associés du manga (titres alternatifs)
- Image de couverture agrandissable au clic avec zoom
- Design modernisé : informations principales en badges, affichage auteur/artiste amélioré

### 🐛 Corrections
- Correction de l'affichage des chapitres dans les sections déjà ouvertes
- Interface plus compacte et lisible
<!-- CHANGELOG:END -->

## 📋 Détails techniques (pour les développeurs)

- Ajout du système d'organisation des chapitres par saisons avec `ChapterSectionHelper`
- Affichage des noms associés (`associated`) dans une section repliable avec ExpansionTile
- Refonte complète de l'UI de `LateDetailView` avec un design plus moderne et compact
- Réduction de l'espacement vertical entre les chapitres dans `RowChapter`
- Suppression de la redondance du numéro de chapitre (affiché deux fois auparavant)
- Ajout d'un système de suivi d'état pour les sections chargées (`_isStateLoaded`, `ValueKey`)
- Gestion des cas où la somme des chapitres par saison ne correspond pas au total (chapitres récents non encore assignés)
- Groupement automatique des chapitres par groupes de 100 pour les mangas sans saisons mais avec beaucoup de chapitres
- Remplacement de tous les `print` par `debugPrint` pour un meilleur logging

