### PR TITLE
fix(auth): popup Google web bloquée par le navigateur

### DIFF
--- a/lib/features/auth/services/auth.service.dart
+++ b/lib/features/auth/services/auth.service.dart
@@ -8,6 +8,8 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:http/http.dart' as http;
 import 'package:mangatracker/core/network/network_compat.dart';
 import 'package:mangatracker/core/network/uri_builder.dart';
+import 'package:mangatracker/features/auth/views/google_auth_js_helper_stub.dart'
+    if (dart.library.html) 'package:mangatracker/features/auth/views/google_auth_js_helper_web.dart';
 import 'package:mangatracker/features/auth/views/google_auth_webview.dart';
 import 'package:mangatracker/core/service_locator/service_locator.dart';
 import 'package:mangatracker/features/auth/exceptions/auth_server.exception.dart';
@@ -43,8 +45,10 @@ enum RefreshResult { success, networkError, rejected }
 ///   (typiquement : OAuth client **Android** absent de la console GCP ou
 ///   SHA-1 de signature non déclaré). L'utilisateur ne peut rien y faire —
 ///   message dédié pour que les rapports de bug soient exploitables.
+/// - [popupBlocked] : web uniquement — le navigateur a bloqué la popup
+///   OAuth (window.open → null). Message dédié : autoriser les pop-ups.
 /// - [failed] : toute autre erreur (réseau, backend, token invalide).
-enum GoogleLoginResult { success, cancelled, configError, failed }
+enum GoogleLoginResult { success, cancelled, configError, popupBlocked, failed }
 
 class AuthService {
   StorageService storageService = getIt<StorageService>();
@@ -490,12 +494,25 @@ class AuthService {
   Future<GoogleLoginResult> _loginWithGoogleWeb(BuildContext context) async {
     final oauthUrl = buildApiUri('/auth/google').toString();
 
+    // window.open DOIT être appelé dans la section SYNCHRONE du handler de
+    // tap (avant tout await / Navigator.push) : hors du geste utilisateur,
+    // Brave/Safari bloquent silencieusement la popup et l'écran d'attente
+    // pollait un postMessage qui ne pouvait jamais arriver (bug web 2026-07).
+    final popupOpened = openGoogleOAuthPopup(oauthUrl);
+    if (!popupOpened) {
+      debugPrint('❌ AuthService: popup Google bloquée par le navigateur');
+      return GoogleLoginResult.popupBlocked;
+    }
+
     if (!context.mounted) return GoogleLoginResult.failed;
 
     final result = await Navigator.of(context).push<GoogleAuthResult>(
       MaterialPageRoute(
         fullscreenDialog: true,
-        builder: (_) => GoogleAuthWebView(oauthUrl: oauthUrl),
+        builder: (_) => GoogleAuthWebView(
+          oauthUrl: oauthUrl,
+          popupAlreadyOpened: true,
+        ),
       ),
     );
 

--- a/lib/features/auth/views/google_auth_js_helper_stub.dart
+++ b/lib/features/auth/views/google_auth_js_helper_stub.dart
@@ -1,3 +1,3 @@
 /// Stubs pour les plateformes non-web (Android, iOS)
-void openGoogleOAuthPopup(String url) {}
+bool openGoogleOAuthPopup(String url) => false;
 Map<String, String>? readGoogleAuthResult() => null;

--- a/lib/features/auth/views/google_auth_js_helper_web.dart
+++ b/lib/features/auth/views/google_auth_js_helper_web.dart
@@ -3,8 +3,13 @@ import 'dart:js' as js;
 
 /// Ouvre la popup Google OAuth via window.open() sans "noopener"
 /// afin que window.opener soit disponible dans la popup pour le postMessage.
-void openGoogleOAuthPopup(String url) {
-  js.context.callMethod('openGoogleOAuthPopup', [url]);
+///
+/// Retourne `false` si le navigateur a bloqué la popup. À appeler dans la
+/// section SYNCHRONE d'un handler de tap (user activation), sinon
+/// Brave/Safari bloquent systématiquement.
+bool openGoogleOAuthPopup(String url) {
+  final result = js.context.callMethod('openGoogleOAuthPopup', [url]);
+  return result == true;
 }
 
 /// Lit le résultat Google OAuth stocké dans window.__googleAuthResult

--- a/lib/features/auth/views/google_auth_webview.dart
+++ b/lib/features/auth/views/google_auth_webview.dart
@@ -25,7 +25,16 @@ class GoogleAuthResult {
 class GoogleAuthWebView extends StatefulWidget {
   final String oauthUrl;
 
-  const GoogleAuthWebView({super.key, required this.oauthUrl});
+  /// Web : vrai si la popup a déjà été ouverte par l'appelant DANS le geste
+  /// utilisateur (obligatoire pour passer les bloqueurs de popups —
+  /// l'ouvrir ici, dans initState, arrive après le tap et se fait bloquer).
+  final bool popupAlreadyOpened;
+
+  const GoogleAuthWebView({
+    super.key,
+    required this.oauthUrl,
+    this.popupAlreadyOpened = false,
+  });
 
   @override
   State<GoogleAuthWebView> createState() => _GoogleAuthWebViewState();
@@ -49,8 +58,12 @@ class _GoogleAuthWebViewState extends State<GoogleAuthWebView> {
 
   /// Web : ouvre une popup via window.open() (sans noopener) et poll le résultat
   Future<void> _launchWebOAuth() async {
-    // window.open() sans "noopener" → window.opener disponible dans la popup
-    openGoogleOAuthPopup(widget.oauthUrl);
+    // window.open() sans "noopener" → window.opener disponible dans la popup.
+    // Si l'appelant l'a déjà ouverte dans le geste utilisateur (cas nominal),
+    // ne pas rouvrir : ici on est hors geste → les bloqueurs refuseraient.
+    if (!widget.popupAlreadyOpened) {
+      openGoogleOAuthPopup(widget.oauthUrl);
+    }
 
     // Polling toutes les 500ms pour détecter les tokens postMessage
     _pollTimer = Timer.periodic(const Duration(milliseconds: 500), (_) {

--- a/lib/features/auth/views/login.view.dart
+++ b/lib/features/auth/views/login.view.dart
@@ -136,6 +136,11 @@ class _LoginViewState extends State<LoginView> {
           l10n?.googleLoginConfigError ??
               "Connexion Google indisponible (erreur de configuration de l'app)",
         );
+      case GoogleLoginResult.popupBlocked:
+        _notifier.error(
+          l10n?.googlePopupBlocked ??
+              'Fenêtre bloquée par le navigateur — autorisez les pop-ups pour ce site',
+        );
       case GoogleLoginResult.failed:
         _notifier.error(
           l10n?.googleLoginFailed ?? 'Échec de la connexion Google',

--- a/lib/features/auth/views/register.view.dart
+++ b/lib/features/auth/views/register.view.dart
@@ -142,6 +142,11 @@ class _RegisterViewState extends State<RegisterView> {
           l10n?.googleLoginConfigError ??
               "Connexion Google indisponible (erreur de configuration de l'app)",
         );
+      case GoogleLoginResult.popupBlocked:
+        getIt<Notifier>().error(
+          l10n?.googlePopupBlocked ??
+              'Fenêtre bloquée par le navigateur — autorisez les pop-ups pour ce site',
+        );
       case GoogleLoginResult.failed:
         getIt<Notifier>().error(
           l10n?.googleLoginFailed ?? 'Échec de la connexion Google',

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -8,6 +8,7 @@
   "login": "Anmelden",
   "googleLoginFailed": "Google-Anmeldung fehlgeschlagen",
   "googleLoginConfigError": "Google-Anmeldung nicht verfügbar (App-Konfigurationsfehler)",
+  "googlePopupBlocked": "Anmeldefenster vom Browser blockiert — erlauben Sie Pop-ups für diese Website und versuchen Sie es erneut",
   "loginWithGoogle": "Mit Google anmelden",
   "back": "Zurück",
   "signUp": "Registrieren",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -8,6 +8,7 @@
   "login": "Sign in",
   "googleLoginFailed": "Google sign-in failed",
   "googleLoginConfigError": "Google sign-in unavailable (app configuration error)",
+  "googlePopupBlocked": "Sign-in window blocked by the browser — allow pop-ups for this site and try again",
   "loginWithGoogle": "Sign in with Google",
   "back": "Back",
   "signUp": "Sign up",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -8,6 +8,7 @@
   "login": "Iniciar sesión",
   "googleLoginFailed": "Error al iniciar sesión con Google",
   "googleLoginConfigError": "Inicio de sesión con Google no disponible (error de configuración de la app)",
+  "googlePopupBlocked": "Ventana de inicio de sesión bloqueada por el navegador — permite las ventanas emergentes para este sitio e inténtalo de nuevo",
   "loginWithGoogle": "Iniciar sesión con Google",
   "back": "Atrás",
   "signUp": "Registrarse",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -32,6 +32,10 @@
   "@googleLoginConfigError": {
     "description": "Erreur quand le SDK Google refuse la configuration de l'app (OAuth client Android / SHA-1 manquant dans la console GCP)"
   },
+  "googlePopupBlocked": "Fenêtre de connexion bloquée par le navigateur — autorisez les pop-ups pour ce site puis réessayez",
+  "@googlePopupBlocked": {
+    "description": "Web uniquement : le navigateur a bloqué la popup OAuth Google (window.open null)"
+  },
   "loginWithGoogle": "Se connecter avec Google",
   "@loginWithGoogle": {
     "description": "Bouton connexion Google"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -8,6 +8,7 @@
   "login": "サインイン",
   "googleLoginFailed": "Googleログインに失敗しました",
   "googleLoginConfigError": "Googleログインを利用できません（アプリ設定エラー）",
+  "googlePopupBlocked": "ログインウィンドウがブラウザにブロックされました。このサイトのポップアップを許可して再試行してください",
   "loginWithGoogle": "Googleでサインイン",
   "back": "戻る",
   "signUp": "サインアップ",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -8,6 +8,7 @@
   "login": "로그인",
   "googleLoginFailed": "Google 로그인 실패",
   "googleLoginConfigError": "Google 로그인을 사용할 수 없습니다 (앱 구성 오류)",
+  "googlePopupBlocked": "브라우저가 로그인 창을 차단했습니다. 이 사이트의 팝업을 허용한 후 다시 시도하세요",
   "loginWithGoogle": "Google로 로그인",
   "back": "뒤로",
   "signUp": "회원가입",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -156,6 +156,12 @@ abstract class AppLocalizations {
   /// **'Connexion Google indisponible (erreur de configuration de l\'application)'**
   String get googleLoginConfigError;
 
+  /// Web uniquement : le navigateur a bloqué la popup OAuth Google (window.open null)
+  ///
+  /// In fr, this message translates to:
+  /// **'Fenêtre de connexion bloquée par le navigateur — autorisez les pop-ups pour ce site puis réessayez'**
+  String get googlePopupBlocked;
+
   /// Bouton connexion Google
   ///
   /// In fr, this message translates to:

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -34,6 +34,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Google-Anmeldung nicht verfügbar (App-Konfigurationsfehler)';
 
   @override
+  String get googlePopupBlocked =>
+      'Anmeldefenster vom Browser blockiert — erlauben Sie Pop-ups für diese Website und versuchen Sie es erneut';
+
+  @override
   String get loginWithGoogle => 'Mit Google anmelden';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -34,6 +34,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Google sign-in unavailable (app configuration error)';
 
   @override
+  String get googlePopupBlocked =>
+      'Sign-in window blocked by the browser — allow pop-ups for this site and try again';
+
+  @override
   String get loginWithGoogle => 'Sign in with Google';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -34,6 +34,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Inicio de sesión con Google no disponible (error de configuración de la app)';
 
   @override
+  String get googlePopupBlocked =>
+      'Ventana de inicio de sesión bloqueada por el navegador — permite las ventanas emergentes para este sitio e inténtalo de nuevo';
+
+  @override
   String get loginWithGoogle => 'Iniciar sesión con Google';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -34,6 +34,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Connexion Google indisponible (erreur de configuration de l\'application)';
 
   @override
+  String get googlePopupBlocked =>
+      'Fenêtre de connexion bloquée par le navigateur — autorisez les pop-ups pour ce site puis réessayez';
+
+  @override
   String get loginWithGoogle => 'Se connecter avec Google';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -33,6 +33,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get googleLoginConfigError => 'Googleログインを利用できません（アプリ設定エラー）';
 
   @override
+  String get googlePopupBlocked =>
+      'ログインウィンドウがブラウザにブロックされました。このサイトのポップアップを許可して再試行してください';
+
+  @override
   String get loginWithGoogle => 'Googleでサインイン';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -33,6 +33,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get googleLoginConfigError => 'Google 로그인을 사용할 수 없습니다 (앱 구성 오류)';
 
   @override
+  String get googlePopupBlocked =>
+      '브라우저가 로그인 창을 차단했습니다. 이 사이트의 팝업을 허용한 후 다시 시도하세요';
+
+  @override
   String get loginWithGoogle => 'Google로 로그인';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -34,6 +34,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Login com Google indisponível (erro de configuração do app)';
 
   @override
+  String get googlePopupBlocked =>
+      'Janela de login bloqueada pelo navegador — permita pop-ups para este site e tente novamente';
+
+  @override
   String get loginWithGoogle => 'Entrar com Google';
 
   @override

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -8,6 +8,7 @@
   "login": "Entrar",
   "googleLoginFailed": "Falha no login com Google",
   "googleLoginConfigError": "Login com Google indisponível (erro de configuração do app)",
+  "googlePopupBlocked": "Janela de login bloqueada pelo navegador — permita pop-ups para este site e tente novamente",
   "loginWithGoogle": "Entrar com Google",
   "back": "Voltar",
   "signUp": "Cadastrar",

--- a/web/index.html
+++ b/web/index.html
@@ -46,9 +46,12 @@
       }
     });
 
-    // Ouvre la popup Google OAuth SANS "noopener" pour que window.opener soit disponible
+    // Ouvre la popup Google OAuth SANS "noopener" pour que window.opener soit disponible.
+    // Retourne false si le navigateur a bloqué la popup (window.open → null),
+    // pour que l'app affiche un message au lieu d'attendre indéfiniment.
     window.openGoogleOAuthPopup = function(url) {
-      window.open(url, 'googleOAuth', 'width=520,height=640,left=200,top=100');
+      var w = window.open(url, 'googleOAuth', 'width=520,height=640,left=200,top=100');
+      return w !== null && typeof w !== 'undefined';
     };
   </script>
   <script src="flutter_bootstrap.js" async></script>


### PR DESCRIPTION
**Symptôme** : sur navigateur, « Se connecter avec Google » affiche l'écran d'attente mais rien ne se passe.

**Cause (reproduite en prod)** : la popup OAuth était ouverte dans \initState\ de l'écran d'attente — hors du geste utilisateur → **bloquée silencieusement** par Brave/Safari. Le serveur est hors de cause : le callback \/auth/google/callback\ échange bien le code (vérifié en prod, « Connexion réussie »).

**Fix** : \window.open\ déplacé dans la section synchrone du tap ; détection du blocage (\window.open\ → null) → \GoogleLoginResult.popupBlocked\ + message dédié ×7 langues ; l'écran d'attente ne rouvre plus la popup.

\[skip release]\ dans le commit : seul le web est affecté — pas de release APK inutile, le web-deploy suffit.

Tests : 30/30, analyze propre, \lutter build web\ OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)